### PR TITLE
feat: API to lock funds

### DIFF
--- a/migrations/20251113120046_update_pending_transactions_schema.sql
+++ b/migrations/20251113120046_update_pending_transactions_schema.sql
@@ -1,0 +1,31 @@
+-- Add migration script here
+
+-- Rename the existing pending_transactions table
+ALTER TABLE pending_transactions RENAME TO old_pending_transactions;
+
+-- Create the new pending_transactions table with the updated schema
+CREATE TABLE pending_transactions (
+    id TEXT PRIMARY KEY NOT NULL,
+    account_id INTEGER NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    status TEXT NOT NULL,
+    requires_change_output BOOLEAN NOT NULL DEFAULT FALSE,
+    total_value INTEGER NOT NULL DEFAULT 0,
+    fee_without_change INTEGER NOT NULL DEFAULT 0,
+    fee_with_change INTEGER NOT NULL DEFAULT 0,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (account_id) REFERENCES accounts(id),
+    UNIQUE (account_id, idempotency_key)
+);
+
+-- Copy data from the old table to the new table
+INSERT INTO pending_transactions (id, account_id, idempotency_key, status, expires_at, created_at)
+SELECT id, account_id, idempotency_key, status, expires_at, created_at
+FROM old_pending_transactions;
+
+-- Drop the old table
+DROP TABLE old_pending_transactions;
+
+-- Recreate the index
+CREATE INDEX idx_pending_transactions_status_expires_at ON pending_transactions(status, expires_at);

--- a/openapi.json
+++ b/openapi.json
@@ -130,6 +130,77 @@
           }
         }
       }
+    },
+    "/accounts/{name}/lock_funds": {
+      "post": {
+        "tags": [
+          "accounts"
+        ],
+        "operationId": "api_lock_funds",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the account to lock funds from",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LockFundsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Funds locked successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LockFundsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -204,6 +275,17 @@
           {
             "type": "object",
             "required": [
+              "FailedToLockFunds"
+            ],
+            "properties": {
+              "FailedToLockFunds": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
               "FailedCreateUnsignedTx"
             ],
             "properties": {
@@ -240,6 +322,91 @@
             "format": "int64",
             "default": "86400",
             "minimum": 0
+          }
+        }
+      },
+      "LockFundsRequest": {
+        "type": "object",
+        "required": [
+          "amount"
+        ],
+        "properties": {
+          "amount": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "estimated_output_size": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "fee_per_gram": {
+            "type": "integer",
+            "format": "int64",
+            "default": "5",
+            "minimum": 0
+          },
+          "idempotency_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "num_outputs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "default": "1",
+            "minimum": 0
+          },
+          "seconds_to_lock_utxos": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "default": "86400",
+            "minimum": 0
+          }
+        }
+      },
+      "LockFundsResponse": {
+        "type": "object",
+        "required": [
+          "utxos",
+          "requires_change_output",
+          "total_value",
+          "fee_without_change",
+          "fee_with_change"
+        ],
+        "properties": {
+          "fee_with_change": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "fee_without_change": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "requires_change_output": {
+            "type": "boolean"
+          },
+          "total_value": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "utxos": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           }
         }
       },

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -7,9 +7,15 @@ use utoipa::IntoParams;
 
 use super::error::ApiError;
 use crate::{
-    api::{AppState, types::TariAddressBase58},
+    api::{
+        AppState,
+        types::{LockFundsResponse, TariAddressBase58},
+    },
     db::{AccountBalance, get_account_by_name, get_balance},
-    transactions::one_sided_transaction::{OneSidedTransaction, Recipient},
+    transactions::{
+        lock_amount::LockAmount,
+        one_sided_transaction::{OneSidedTransaction, Recipient},
+    },
 };
 use tari_transaction_components::tari_amount::MicroMinotari;
 
@@ -17,9 +23,40 @@ fn default_seconds_to_lock_utxos() -> Option<u64> {
     Some(86400)
 }
 
+fn default_num_outputs() -> Option<usize> {
+    Some(1)
+}
+
+fn default_fee_per_gram() -> Option<MicroMinotari> {
+    Some(MicroMinotari(5))
+}
+
 #[derive(Debug, serde::Deserialize, IntoParams, utoipa::ToSchema)]
 pub struct WalletParams {
     name: String,
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct LockFundsRequest {
+    #[schema(value_type = u64)]
+    pub amount: MicroMinotari,
+
+    #[serde(default = "default_num_outputs")]
+    #[schema(default = "1")]
+    pub num_outputs: Option<usize>,
+
+    #[schema(value_type = u64)]
+    #[serde(default = "default_fee_per_gram")]
+    #[schema(default = "5")]
+    pub fee_per_gram: Option<MicroMinotari>,
+
+    pub estimated_output_size: Option<usize>,
+
+    #[serde(default = "default_seconds_to_lock_utxos")]
+    #[schema(default = "86400")]
+    pub seconds_to_lock_utxos: Option<u64>,
+
+    pub idempotency_key: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
@@ -67,6 +104,46 @@ pub async fn api_get_balance(
 
 #[utoipa::path(
     post,
+    path = "/accounts/{name}/lock_funds",
+    request_body = LockFundsRequest,
+    responses(
+        (status = 200, description = "Funds locked successfully", body = LockFundsResponse),
+        (status = 400, description = "Bad request", body = ApiError),
+        (status = 404, description = "Account not found", body = ApiError),
+        (status = 500, description = "Internal server error", body = ApiError),
+    ),
+    params(
+        ("name" = String, Path, description = "Name of the account to lock funds from"),
+    )
+)]
+pub async fn api_lock_funds(
+    State(app_state): State<AppState>,
+    Path(WalletParams { name }): Path<WalletParams>,
+    Json(body): Json<LockFundsRequest>,
+) -> Result<Json<LockFundsResponse>, ApiError> {
+    let mut conn = app_state.db_pool.acquire().await?;
+    let account = get_account_by_name(&mut conn, &name)
+        .await?
+        .ok_or_else(|| ApiError::AccountNotFound(name.clone()))?;
+
+    let lock_amount = LockAmount::new(app_state.db_pool.clone());
+    let response = lock_amount
+        .lock(
+            &account,
+            body.amount,
+            body.num_outputs.expect("must be defaulted"),
+            body.fee_per_gram.expect("must be defaulted"),
+            body.estimated_output_size,
+            body.idempotency_key,
+            body.seconds_to_lock_utxos.expect("must be defaulted"),
+        )
+        .await
+        .map_err(|e| ApiError::FailedToLockFunds(e.to_string()))?;
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    post,
     path = "/accounts/{name}/create_unsigned_transaction",
     request_body = CreateTransactionRequest,
     responses(
@@ -94,22 +171,35 @@ pub async fn api_create_unsigned_transaction(
         })
         .collect();
 
-    let seconds_to_lock_utxos = body.seconds_to_lock_utxos;
-
     let mut conn = app_state.db_pool.acquire().await?;
     let account = get_account_by_name(&mut conn, &name)
         .await?
         .ok_or_else(|| ApiError::AccountNotFound(name.clone()))?;
 
+    let amount = recipients.iter().map(|r| r.amount).sum();
+    let num_outputs = recipients.len();
+    let fee_per_gram = MicroMinotari(5);
+    let estimated_output_size = None;
+    let seconds_to_lock_utxos = body.seconds_to_lock_utxos.unwrap_or(86400); // 24 hours
+
+    let lock_amount = LockAmount::new(app_state.db_pool.clone());
+    let locked_funds = lock_amount
+        .lock(
+            &account,
+            amount,
+            num_outputs,
+            fee_per_gram,
+            estimated_output_size,
+            body.idempotency_key,
+            seconds_to_lock_utxos,
+        )
+        .await
+        .map_err(|e| ApiError::FailedToLockFunds(e.to_string()))?;
+
     let one_sided_tx =
         OneSidedTransaction::new(app_state.db_pool.clone(), app_state.network, app_state.password.clone());
     let result = one_sided_tx
-        .create_unsigned_transaction(
-            account,
-            recipients,
-            body.idempotency_key,
-            seconds_to_lock_utxos.unwrap(),
-        )
+        .create_unsigned_transaction(&account, locked_funds, recipients, fee_per_gram)
         .await
         .map_err(|e| ApiError::FailedCreateUnsignedTx(e.to_string()))?;
 

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -16,6 +16,8 @@ pub enum ApiError {
     DbError(String),
     #[error("Account not found: {0}")]
     AccountNotFound(String),
+    #[error("Failed to lock funds: {0}")]
+    FailedToLockFunds(String),
     #[error("Failed to create an unsigned transaction: {0}")]
     FailedCreateUnsignedTx(String),
 }
@@ -38,6 +40,7 @@ impl IntoResponse for ApiError {
             ApiError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             ApiError::DbError(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
             ApiError::AccountNotFound(name) => (StatusCode::NOT_FOUND, format!("Account '{}' not found", name)),
+            ApiError::FailedToLockFunds(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
             ApiError::FailedCreateUnsignedTx(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
         };
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,9 +4,9 @@ use tari_common::configuration::Network;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-mod accounts;
+pub mod accounts;
 mod error;
-mod types;
+pub mod types;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -25,15 +25,18 @@ impl FromRef<AppState> for SqlitePool {
 #[openapi(
     paths(
         accounts::api_get_balance,
+        accounts::api_lock_funds,
         accounts::api_create_unsigned_transaction,
     ),
     components(
         schemas(
             crate::db::AccountBalance,
             error::ApiError,
+            accounts::WalletParams,
+            accounts::LockFundsRequest,
             accounts::CreateTransactionRequest,
             accounts::RecipientRequest,
-            accounts::WalletParams,
+            crate::api::types::LockFundsResponse,
             crate::api::types::TariAddressBase58,
         )
     ),
@@ -53,6 +56,7 @@ pub fn create_router(db_pool: SqlitePool, network: Network, password: String) ->
     Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/openapi.json", ApiDoc::openapi()))
         .route("/accounts/{name}/balance", get(accounts::api_get_balance))
+        .route("/accounts/{name}/lock_funds", post(accounts::api_lock_funds))
         .route(
             "/accounts/{name}/create_unsigned_transaction",
             post(accounts::api_create_unsigned_transaction),

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,10 +1,28 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use tari_common_types::tari_address::TariAddress;
+use tari_transaction_components::{tari_amount::MicroMinotari, transaction_components::WalletOutput};
 
 // Helper struct for serializing/deserializing TariAddress as a hex string
 #[derive(Debug, Clone, PartialEq, Eq, utoipa::ToSchema)]
 #[schema(value_type = String)]
 pub struct TariAddressBase58(pub TariAddress);
+
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct LockFundsResponse {
+    #[schema(value_type = Vec<Object>)]
+    pub utxos: Vec<WalletOutput>,
+
+    pub requires_change_output: bool,
+
+    #[schema(value_type = u64)]
+    pub total_value: MicroMinotari,
+
+    #[schema(value_type = u64)]
+    pub fee_without_change: MicroMinotari,
+
+    #[schema(value_type = u64)]
+    pub fee_with_change: MicroMinotari,
+}
 
 impl Serialize for TariAddressBase58 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/transactions/lock_amount.rs
+++ b/src/transactions/lock_amount.rs
@@ -1,0 +1,75 @@
+use chrono::{Duration, Utc};
+use sqlx::SqlitePool;
+use tari_transaction_components::tari_amount::MicroMinotari;
+use uuid::Uuid;
+
+use crate::{
+    api::types::LockFundsResponse,
+    db::{self, AccountRow},
+    transactions::input_selector::InputSelector,
+};
+
+pub struct LockAmount {
+    db_pool: SqlitePool,
+}
+
+impl LockAmount {
+    pub fn new(db_pool: SqlitePool) -> Self {
+        Self { db_pool }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn lock(
+        &self,
+        account: &AccountRow,
+        amount: MicroMinotari,
+        num_outputs: usize,
+        fee_per_gram: MicroMinotari,
+        estimated_output_size: Option<usize>,
+        idempotency_key: Option<String>,
+        seconds_to_lock_utxos: u64,
+    ) -> Result<LockFundsResponse, anyhow::Error> {
+        let mut conn = self.db_pool.acquire().await?;
+        if let Some(idempotency_key_str) = &idempotency_key
+            && let Some(response) =
+                db::find_pending_transaction_by_idempotency_key(&mut conn, idempotency_key_str, account.id).await?
+        {
+            return Ok(response);
+        }
+
+        let input_selector = InputSelector::new(account.id);
+        let utxo_selection = input_selector
+            .fetch_unspent_outputs(&mut conn, amount, num_outputs, fee_per_gram, estimated_output_size)
+            .await?;
+
+        let mut transaction = self.db_pool.begin().await?;
+
+        let expires_at = Utc::now() + Duration::seconds(seconds_to_lock_utxos as i64);
+        let idempotency_key = idempotency_key.unwrap_or_else(|| Uuid::new_v4().to_string());
+        let pending_tx_id = db::create_pending_transaction(
+            &mut transaction,
+            &idempotency_key,
+            account.id,
+            utxo_selection.requires_change_output,
+            utxo_selection.total_value,
+            utxo_selection.fee_without_change,
+            utxo_selection.fee_with_change,
+            expires_at,
+        )
+        .await?;
+
+        for utxo in &utxo_selection.utxos {
+            db::lock_output(&mut transaction, utxo.id, &pending_tx_id, expires_at).await?;
+        }
+
+        transaction.commit().await?;
+
+        Ok(LockFundsResponse {
+            utxos: utxo_selection.utxos.iter().map(|utxo| utxo.output.clone()).collect(),
+            requires_change_output: utxo_selection.requires_change_output,
+            total_value: utxo_selection.total_value,
+            fee_without_change: utxo_selection.fee_without_change,
+            fee_with_change: utxo_selection.fee_with_change,
+        })
+    }
+}

--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -1,2 +1,3 @@
 pub mod input_selector;
+pub mod lock_amount;
 pub mod one_sided_transaction;

--- a/src/transactions/one_sided_transaction.rs
+++ b/src/transactions/one_sided_transaction.rs
@@ -1,5 +1,4 @@
 use anyhow::anyhow;
-use chrono::{Duration, Utc};
 use sqlx::SqlitePool;
 use tari_common::configuration::Network;
 use tari_common_types::{tari_address::TariAddress, transaction::TxId};
@@ -10,12 +9,8 @@ use tari_transaction_components::{
     tari_amount::MicroMinotari,
     transaction_components::{MemoField, OutputFeatures, memo_field::TxType},
 };
-use uuid::Uuid;
 
-use crate::{
-    db::{self, AccountRow},
-    transactions::input_selector::InputSelector,
-};
+use crate::{api::types::LockFundsResponse, db::AccountRow};
 
 #[derive(Debug, Clone)]
 pub struct Recipient {
@@ -41,21 +36,11 @@ impl OneSidedTransaction {
 
     pub async fn create_unsigned_transaction(
         &self,
-        account: AccountRow,
+        account: &AccountRow,
+        locked_funds: LockFundsResponse,
         recipients: Vec<Recipient>,
-        idempotency_key: Option<String>,
-        seconds_to_lock_utxos: u64,
+        fee_per_gram: MicroMinotari,
     ) -> Result<PrepareOneSidedTransactionForSigningResult, anyhow::Error> {
-        let mut conn = self.db_pool.acquire().await?;
-        if let Some(idempotency_key_str) = &idempotency_key
-            && let Some(unsigned_tx_json) =
-                db::find_pending_transaction_by_idempotency_key(&mut conn, idempotency_key_str, account.id).await?
-        {
-            let result: PrepareOneSidedTransactionForSigningResult =
-                serde_json::from_str(&unsigned_tx_json).map_err(|e| anyhow!(e))?;
-            return Ok(result);
-        }
-
         if recipients.is_empty() {
             return Err(anyhow!("No recipients provided"));
         }
@@ -67,20 +52,14 @@ impl OneSidedTransaction {
 
         let sender_address = account.get_address(self.network, &self.password)?;
 
-        let input_selector = InputSelector::new(account.id);
-        let fee_per_gram = MicroMinotari(5);
-        let utxo_selection = input_selector
-            .fetch_unspent_outputs(&mut conn, recipient.amount, fee_per_gram)
-            .await?;
-
         let key_manager = account.get_key_manager(&self.password).await?;
         let consensus_constants = ConsensusConstantsBuilder::new(self.network).build();
         let mut tx_builder = TransactionBuilder::new(consensus_constants, key_manager.clone(), self.network)?;
 
         tx_builder.with_fee_per_gram(fee_per_gram);
 
-        for utxo in &utxo_selection.utxos {
-            tx_builder.with_input(utxo.output.clone())?;
+        for utxo in &locked_funds.utxos {
+            tx_builder.with_input(utxo.clone())?;
         }
 
         let mut offline_signing = OfflineSigner::new(key_manager);
@@ -100,26 +79,6 @@ impl OneSidedTransaction {
             payment_id,
             sender_address,
         )?;
-
-        let mut transaction = self.db_pool.begin().await?;
-
-        let expires_at = Utc::now() + Duration::seconds(seconds_to_lock_utxos as i64);
-        let unsigned_tx_json = serde_json::to_string(&result).map_err(|e| anyhow!(e))?;
-        let idempotency_key = idempotency_key.unwrap_or_else(|| Uuid::new_v4().to_string());
-        let pending_tx_id = db::create_pending_transaction(
-            &mut transaction,
-            &idempotency_key,
-            account.id,
-            &unsigned_tx_json,
-            expires_at,
-        )
-        .await?;
-
-        for utxo in utxo_selection.utxos {
-            db::lock_output(&mut transaction, utxo.id, &pending_tx_id, expires_at).await?;
-        }
-
-        transaction.commit().await?;
 
         Ok(result)
     }


### PR DESCRIPTION
Description
---

As part of our [**Payment Processor TX flow update**](https://github.com/tari-project/minotari_payment_processor/issues/3) we need the **Payment Receiver** to support both:
- locking and returning UTXOs based on requested amount
- creating an offline signing request (should use the same locking mechanism)


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
