### PR TITLE
fix: revert only `LOCKED` outputs when they expire

### DIFF
--- a/src/db/outputs.rs
+++ b/src/db/outputs.rs
@@ -288,14 +288,16 @@ pub async fn unlock_outputs_for_request(
     locked_by_request_id: &str,
 ) -> Result<(), sqlx::Error> {
     let unspent_status = OutputStatus::Unspent.to_string();
+    let locked_status = OutputStatus::Locked.to_string();
     sqlx::query!(
         r#"
         UPDATE outputs
         SET status = ?, locked_at = NULL, locked_by_request_id = NULL
-        WHERE locked_by_request_id = ?
+        WHERE locked_by_request_id = ? AND status = ?
         "#,
         unspent_status,
         locked_by_request_id,
+        locked_status
     )
     .execute(&mut *conn)
     .await?;


### PR DESCRIPTION
Description
---

The fix adds a condition to the **UPDATE query**. We should only unlock outputs that are still in the `LOCKED` state. This ensures we don't interfere with outputs that have been correctly marked as `SPENT` by base node sync.

Motivation and Context
---

When a transaction lock expires, it **incorrectly reverts** the status of all associated outputs to `UNSPENT`, even if they have already been successfully `SPENT`. This can cause outputs that are part of a completed transaction to reappear as spendable, which is incorrect.


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
