### PR TITLE
fix: payref calculation

### DIFF
--- a/docs/db/db_schema.sql
+++ b/docs/db/db_schema.sql
@@ -117,7 +117,7 @@ CREATE TABLE completed_transactions (
     broadcast_attempts INTEGER NOT NULL DEFAULT 0,
     serialized_transaction BLOB NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, sent_output_hash TEXT,
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     FOREIGN KEY (pending_tx_id) REFERENCES pending_transactions(id)
 );

--- a/migrations/20251209111623_add_sent_output_hash_to_completed_transactions.sql
+++ b/migrations/20251209111623_add_sent_output_hash_to_completed_transactions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE completed_transactions ADD COLUMN sent_output_hash TEXT;

--- a/src/transactions/manager.rs
+++ b/src/transactions/manager.rs
@@ -337,7 +337,7 @@ impl TransactionSender {
         let serialized_transaction = serde_json::to_vec(&signed_transaction.signed_transaction.transaction)
             .map_err(|e| anyhow!("Failed to serialize transaction: {}", e))?;
 
-        let sent_payref = signed_transaction
+        let sent_output_hash = signed_transaction
             .signed_transaction
             .sent_hashes
             .first()
@@ -364,7 +364,7 @@ impl TransactionSender {
             processed_transaction.id(),
             &kernel_excess,
             &serialized_transaction,
-            sent_payref,
+            sent_output_hash,
         )
         .await?;
 


### PR DESCRIPTION
Description
---

Moves `payref` calculation and storage to the point of block confirmation.

Fixes: #29

Motivation and Context
---

Previously, we were incorrectly storing the output hash in `sent_payref` immediately before broadcasting.
This PR introduces a new DB field, `sent_output_hash`, to store the output hash.
The `sent_payref` is now updated only after the block is confirmed.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
