### PR TITLE
fix: allow wallet to run in daemon mode

### DIFF
--- a/src/scan/scan.rs
+++ b/src/scan/scan.rs
@@ -587,12 +587,7 @@ impl Scanner {
         let mut all_events = Vec::new();
         let mut any_more_blocks = false;
 
-        let account_name = self
-            .account_name
-            .clone()
-            .ok_or_else(|| ScanError::Fatal(anyhow::anyhow!("Account name must be set")))?;
-
-        let accounts = db::get_accounts(&mut conn, Some(&account_name)).await?;
+        let accounts = db::get_accounts(&mut conn, self.account_name.as_deref()).await?;
 
         for account in accounts {
             let monitoring_state = MonitoringState::new();


### PR DESCRIPTION
Description
---

Allows the wallet to run in daemon mode, when it scans all wallets.

Motivation and Context
---

Wallet was crashing, when run in daemon mode:
```sh
$ cargo run --bin minotari \
  -- daemon \
  --password password \
  --base-url http://localhost:9005 \
  --database-file data/wallet.db \
  --batch-size 100 \
  --network esmeralda

Starting Tari wallet daemon...                                                                                                                                                                                                              
Daemon started. Press Ctrl+C to stop.

Transaction unlocker task started.                                                                                    
API server listening on 0.0.0.0:9000
Starting wallet scan...             

Scan failed: Fatal error: Account name must be set                                                                    
A fatal error occurred during the scan cycle: Fatal error: Account name must be set
Transaction unlocker task received shutdown signal. Exiting gracefully.
Transaction unlocker task has shut down.  
Error: Fatal error: Account name must be set
                                                           
Caused by:                                 
    Account name must be set     
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
