### PR TITLE
chore: add default run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minotari"
 version = "0.1.0"
 edition = "2024"
+default-run = "minotari"
 
 [[bin]]
 name = "generate-openapi"


### PR DESCRIPTION
Small pr to enable running `cargo run` without specifying the bin