### PR TITLE
fix: race condition in UTXO locking (#125)

### DIFF
--- a/minotari/src/transactions/fund_locker.rs
+++ b/minotari/src/transactions/fund_locker.rs
@@ -22,6 +22,7 @@
 
 use chrono::{Duration, Utc};
 use log::info;
+use std::sync::Mutex;
 use tari_transaction_components::tari_amount::MicroMinotari;
 use uuid::Uuid;
 
@@ -32,6 +33,18 @@ use crate::{
     transactions::input_selector::InputSelector,
 };
 
+/// Global mutex that serializes all [`FundLocker::lock`] calls.
+///
+/// The idempotency check and UTXO selection are not atomic at the database level;
+/// without this mutex two concurrent requests could both pass the idempotency
+/// check, select the same set of "unspent" outputs, and then race to lock them.
+///
+/// The mutex ensures that only one thread executes the critical section
+/// (idempotency check → UTXO selection → pending-transaction creation →
+/// output locking) at a time, eliminating the race condition described in
+/// <https://github.com/anomalyco/minotari-cli/issues/125>.
+static FUND_LOCK_MUTEX: Mutex<()> = Mutex::new(());
+
 /// Manages temporary locking of UTXOs during transaction construction.
 ///
 /// `FundLocker` ensures that UTXOs selected for a transaction cannot be used
@@ -41,8 +54,10 @@ use crate::{
 ///
 /// # Thread Safety
 ///
-/// `FundLocker` uses database-level locking and can be safely shared across
-/// threads via cloning (which clones the underlying connection pool).
+/// A global [`Mutex`] serialises all [`lock`](FundLocker::lock) calls so that
+/// the idempotency check, UTXO selection, pending-transaction creation, and
+/// output locking happen atomically with respect to other threads.  The struct
+/// itself can be safely shared across threads via cloning.
 ///
 /// # Example
 ///
@@ -152,7 +167,13 @@ impl FundLocker {
             amount = &*mask_amount(amount);
             "Locking funds"
         );
+        // Acquire a database connection first so we don't hold the global
+        // mutex while waiting for a pooled connection (which could deadlock
+        // under pool exhaustion).
         let mut conn = self.db_pool.get()?;
+        // Fast idempotency check (without the global mutex).  If the pending
+        // transaction already exists we can return immediately without waiting
+        // for any concurrent `lock()` call to finish.
         if let Some(idempotency_key_str) = &idempotency_key
             && let Some(response) =
                 db::find_pending_transaction_locked_funds_by_idempotency_key(&conn, idempotency_key_str, account_id)?
@@ -161,6 +182,29 @@ impl FundLocker {
                 target: "audit",
                 idempotency_key = idempotency_key_str.as_str();
                 "Found existing pending transaction lock"
+            );
+            return Ok(response);
+        }
+
+        // Acquire the global mutex so that the idempotency re-check, UTXO
+        // selection, and database transaction are all serialised.  This
+        // prevents a concurrent request from seeing the same "unspent" UTXOs
+        // and creating a duplicate pending transaction.
+        let _guard = FUND_LOCK_MUTEX
+            .lock()
+            .expect("Fund locker mutex poisoned – a prior lock() call panicked");
+        // Re-check idempotency now that we hold the mutex.  The first thread
+        // that passed the fast-path check above may have created the pending
+        // transaction while we were waiting for the lock; if so we return its
+        // result rather than selecting UTXOs a second time.
+        if let Some(idempotency_key_str) = &idempotency_key
+            && let Some(response) =
+                db::find_pending_transaction_locked_funds_by_idempotency_key(&conn, idempotency_key_str, account_id)?
+        {
+            info!(
+                target: "audit",
+                idempotency_key = idempotency_key_str.as_str();
+                "Found existing pending transaction lock (re-check)"
             );
             return Ok(response);
         }
@@ -204,5 +248,287 @@ impl FundLocker {
             fee_without_change: utxo_selection.fee_without_change,
             fee_with_change: utxo_selection.fee_with_change,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::cast_possible_wrap)]
+    #![allow(clippy::cast_lossless)]
+    #![allow(clippy::cast_possible_truncation)]
+    #![allow(clippy::indexing_slicing)]
+
+    use super::*;
+    use crate::db::{create_account, get_account_by_name, init_db, insert_scanned_tip_block};
+    use rusqlite::{Connection, named_params};
+    use std::collections::HashSet;
+    use tari_common_types::{
+        seeds::cipher_seed::CipherSeed,
+        types::{ComAndPubSignature, CompressedPublicKey, FixedHash},
+    };
+    use tari_script::{ExecutionStack, TariScript};
+    use tari_transaction_components::{
+        key_manager::{
+            TariKeyId,
+            wallet_types::{SeedWordsWallet, WalletType},
+        },
+        transaction_components::{
+            EncryptedData, MemoField, OutputFeatures, TransactionOutputVersion, WalletOutput, covenants::Covenant,
+        },
+    };
+    use tempfile::tempdir;
+
+    /// Create a [`WalletOutput`] with the given value and hash seed, plus
+    /// default parameters suitable for testing.
+    fn test_wallet_output(value: u64, hash_seed: u8) -> WalletOutput {
+        let mut hash = FixedHash::default();
+        hash[0] = hash_seed;
+        WalletOutput::new_from_parts(
+            TransactionOutputVersion::default(),
+            MicroMinotari::from(value),
+            TariKeyId::default(),
+            OutputFeatures::default(),
+            TariScript::default(),
+            ExecutionStack::default(),
+            TariKeyId::default(),
+            CompressedPublicKey::default(),
+            ComAndPubSignature::default(),
+            0,
+            Covenant::default(),
+            EncryptedData::default(),
+            MicroMinotari::from(0),
+            None,
+            MemoField::new_empty(),
+            hash,
+            Default::default(),
+        )
+    }
+
+    /// Insert a test output row directly into the database.
+    fn insert_test_output(conn: &Connection, account_id: i64, output_hash_byte: u8, value: u64, mined_height: u64) {
+        let output = test_wallet_output(value, output_hash_byte);
+        let wallet_output_json = serde_json::to_string(&output).expect("serialize WalletOutput");
+        conn.execute(
+            r#"
+            INSERT INTO outputs (
+                account_id, tx_id, output_hash, mined_in_block_height, mined_in_block_hash,
+                value, mined_timestamp, wallet_output_json, status, confirmed_height,
+                confirmed_hash, is_burn, maturity
+            ) VALUES (
+                :account_id, :tx_id, :output_hash, :height, :block_hash,
+                :value, :mined_ts, :json, :status, :confirmed_height,
+                :confirmed_hash, 0, :maturity
+            )
+            "#,
+            named_params! {
+                ":account_id": account_id,
+                ":tx_id": output_hash_byte as i64,
+                ":output_hash": vec![output_hash_byte; 32],
+                ":height": mined_height as i64,
+                ":block_hash": vec![output_hash_byte; 32],
+                ":value": value as i64,
+                ":mined_ts": Utc::now(),
+                ":json": wallet_output_json,
+                ":status": "UNSPENT",
+                ":confirmed_height": mined_height as i64,
+                ":confirmed_hash": vec![output_hash_byte; 32],
+                ":maturity": 0,
+            },
+        )
+        .expect("insert test output");
+    }
+
+    /// Create a fresh in-memory database, initialize it, create a test
+    /// account, and seed a set of spendable UTXOs.  Returns the pool,
+    /// connection, and account id.
+    fn setup_test_env(output_count: usize, value_per_output: u64) -> (SqlitePool, i64, tempfile::TempDir) {
+        let temp = tempdir().expect("temp dir");
+        let pool = init_db(temp.path().join("test.db")).expect("init db");
+        let conn = pool.get().expect("get conn");
+
+        let seeds = CipherSeed::random();
+        let wallet = WalletType::SeedWords(SeedWordsWallet::construct_new(seeds).expect("construct wallet"));
+        create_account(&conn, "test", &wallet, "pass").expect("create account");
+        let account = get_account_by_name(&conn, "test")
+            .expect("get account")
+            .expect("account exists");
+        let account_id = account.id;
+
+        // Insert a scanned tip block so `InputSelector` sees a non-zero tip
+        insert_scanned_tip_block(&conn, account_id, 200, &[0u8; 32]).expect("insert tip block");
+
+        // Insert spendable outputs
+        for i in 0..output_count {
+            insert_test_output(
+                &conn,
+                account_id,
+                (i + 1) as u8,
+                (i as u64 + 1) * value_per_output,
+                100, // mined at block 100 → eligible with window=100, tip=200
+            );
+        }
+
+        drop(conn);
+        (pool, account_id, temp)
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn concurrent_lock_calls_select_disjoint_utxos() {
+        let (pool, account_id, _temp) = setup_test_env(5, 500_000);
+
+        let pool2 = pool.clone();
+        let handle_a = std::thread::spawn(move || {
+            let locker = FundLocker::new(pool);
+            locker.lock(
+                account_id,
+                MicroMinotari(100_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100, // confirmation_window = 100 → tip(200) − 100 = 100 ≥ mined(100)
+            )
+        });
+        let handle_b = std::thread::spawn(move || {
+            let locker = FundLocker::new(pool2);
+            locker.lock(
+                account_id,
+                MicroMinotari(100_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+        });
+
+        let res_a = handle_a.join().expect("thread A panicked");
+        let res_b = handle_b.join().expect("thread B panicked");
+
+        let result_a = res_a.expect("lock A succeeded");
+        let result_b = res_b.expect("lock B succeeded");
+
+        // Each call must have locked at least one UTXO
+        assert!(!result_a.utxos.is_empty(), "A got at least one UTXO");
+        assert!(!result_b.utxos.is_empty(), "B got at least one UTXO");
+
+        // The two result sets must not share any UTXO (identified by its hash)
+        let hashes_a: HashSet<FixedHash> = result_a.utxos.iter().map(|u| u.output_hash()).collect();
+        let hashes_b: HashSet<FixedHash> = result_b.utxos.iter().map(|u| u.output_hash()).collect();
+
+        let intersection: HashSet<_> = hashes_a.intersection(&hashes_b).copied().collect();
+        assert!(
+            intersection.is_empty(),
+            "Concurrent lock calls selected overlapping UTXOs: {intersection:?}",
+        );
+    }
+
+    #[test]
+    fn idempotency_key_returns_same_result_concurrently() {
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        let key = "concurrent-idempotency-key".to_string();
+        let pool2 = pool.clone();
+        let key2 = key.clone();
+
+        let handle_a = std::thread::spawn(move || {
+            let locker = FundLocker::new(pool);
+            locker.lock(
+                account_id,
+                MicroMinotari(200_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                Some(key),
+                3600,
+                100,
+            )
+        });
+        let handle_b = std::thread::spawn(move || {
+            let locker = FundLocker::new(pool2);
+            locker.lock(
+                account_id,
+                MicroMinotari(200_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                Some(key2),
+                3600,
+                100,
+            )
+        });
+
+        let res_a = handle_a.join().expect("thread A panicked");
+        let res_b = handle_b.join().expect("thread B panicked");
+
+        let result_a = res_a.expect("lock A succeeded");
+        let result_b = res_b.expect("lock B succeeded");
+
+        // Both should see the same locked funds (same UTXOs, same totals)
+        let hashes_a: HashSet<FixedHash> = result_a.utxos.iter().map(|u| u.output_hash()).collect();
+        let hashes_b: HashSet<FixedHash> = result_b.utxos.iter().map(|u| u.output_hash()).collect();
+
+        assert_eq!(
+            hashes_a, hashes_b,
+            "Idempotent concurrent calls must return identical UTXO sets",
+        );
+        assert_eq!(result_a.total_value, result_b.total_value);
+        assert_eq!(result_a.requires_change_output, result_b.requires_change_output);
+    }
+
+    #[test]
+    fn mutex_serialises_lock_calls() {
+        // Verify that the global `FUND_LOCK_MUTEX` serialises callers:
+        // two concurrent `lock()` calls on the *same* account both succeed
+        // without overlapping UTXO sets (each sees a disjoint set of UTXOs
+        // because the first call's side-effects are visible to the second).
+        //
+        // This is already exercised by `concurrent_lock_calls_select_disjoint_utxos`
+        // above; this test adds a second scenario using a different account to
+        // ensure the mutex does not prevent different accounts from making
+        // progress (though in practice they share the global lock).
+        let (pool_a, account_a, _temp_a) = setup_test_env(3, 1_000_000);
+        let (pool_b, account_b, _temp_b) = setup_test_env(3, 1_000_000);
+
+        let _pool_a2 = pool_a.clone();
+        let _pool_b2 = pool_b.clone();
+
+        let h_a = std::thread::spawn(move || {
+            FundLocker::new(pool_a).lock(
+                account_a,
+                MicroMinotari(200_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+        });
+        let h_b = std::thread::spawn(move || {
+            FundLocker::new(pool_b).lock(
+                account_b,
+                MicroMinotari(200_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+        });
+
+        let r_a = h_a.join().expect("thread A panicked").expect("lock A ok");
+        let r_b = h_b.join().expect("thread B panicked").expect("lock B ok");
+
+        // Both should succeed (no double-spend errors) and select at least one UTXO
+        assert!(!r_a.utxos.is_empty(), "A got UTXOs");
+        assert!(!r_b.utxos.is_empty(), "B got UTXOs");
     }
 }


### PR DESCRIPTION
## Description

The idempotency check and UTXO selection were not atomic operations. Two concurrent requests could both pass the idempotency check, select the same UTXOs as "unspent", and then race to lock them � resulting in double-spending or transaction failures.

## Solution

Added a global `std::sync::Mutex<()>` to `FundLocker::lock` that serializes the critical section (idempotency check ? UTXO selection ? pending transaction creation ? output locking).

## Acceptance Criteria

- [x] prevent utxo requests to select the same utxos
- [x] prevent same idempotency requests to rerun
- [x] Add unit tests to show its blocked and utxos selection is unique

## Tests

3 unit tests added, all passing:
- `concurrent_lock_calls_select_disjoint_utxos` � two concurrent calls select non-overlapping UTXO sets
- `idempotency_key_returns_same_result_concurrently` � concurrent same-key calls return identical results
- `mutex_serialises_lock_calls` � concurrent calls on different accounts both succeed

Closes #125

Tari wallet adress: 12G1frwwnPxt4SJ72eSUsbP6jUjL5e5tLbmR2anya9Gx15ZcmNQHi838dsJsLAqxKGSHJh47swTPTABPjwD6RpYohUw
