### PR TITLE
fix: utxos locks

### DIFF
--- a/minotari/src/db/error.rs
+++ b/minotari/src/db/error.rs
@@ -32,6 +32,17 @@ pub enum WalletDbError {
     #[error("Duplicate entry: {0}")]
     DuplicateEntry(String),
 
+    /// A UTXO could not be reserved because it was no longer `Unspent` when the
+    /// conditional `UPDATE` ran.
+    ///
+    /// This means another writer (a second CLI invocation, the daemon's scan
+    /// loop marking the output spent, or the unlocker) won the race between
+    /// output selection and locking. The caller must abandon the selection —
+    /// handing back a UTXO it does not own would let two transactions spend the
+    /// same output.
+    #[error("Output {output_id} is no longer unspent and cannot be locked for request {request_id}")]
+    OutputLockConflict { output_id: i64, request_id: String },
+
     #[error("Key decryption failed: {0}")]
     DecryptionFailed(String),
 

--- a/minotari/src/db/outputs.rs
+++ b/minotari/src/db/outputs.rs
@@ -512,6 +512,18 @@ pub fn update_output_status(conn: &Connection, output_id: i64, status: OutputSta
     Ok(())
 }
 
+/// Reserves an output for `locked_by_request_id`, but only if it is still `Unspent`.
+///
+/// The `AND status = :unspent_status` clause makes this a compare-and-swap: the
+/// row transitions `Unspent → Locked` exactly once, no matter how many writers
+/// race for it. The result of that comparison is the whole point of the
+/// statement, so a no-op update is reported as
+/// [`WalletDbError::OutputLockConflict`] rather than being swallowed — silently
+/// returning `Ok(())` on zero rows would hand the caller a UTXO that some other
+/// writer already owns, and both would go on to spend it.
+///
+/// Callers should run this inside the same write transaction that selected the
+/// output, so that a conflict rolls back the whole reservation.
 pub fn lock_output(
     conn: &Connection,
     output_id: i64,
@@ -528,7 +540,7 @@ pub fn lock_output(
     let locked_status = OutputStatus::Locked.to_string();
     let unspent_status = OutputStatus::Unspent.to_string();
 
-    conn.execute(
+    let rows_locked = conn.execute(
         r#"
         UPDATE outputs
         SET status = :locked_status, locked_by_request_id = :req_id, locked_at = :locked_at
@@ -542,6 +554,19 @@ pub fn lock_output(
             ":unspent_status": unspent_status,
         },
     )?;
+
+    if rows_locked == 0 {
+        warn!(
+            target: "audit",
+            output_id = output_id,
+            request_id = locked_by_request_id;
+            "DB: Output is no longer unspent; lock lost the race"
+        );
+        return Err(WalletDbError::OutputLockConflict {
+            output_id,
+            request_id: locked_by_request_id.to_string(),
+        });
+    }
 
     Ok(())
 }
@@ -1046,5 +1071,107 @@ mod tests {
         assert_eq!(totals.available, MicroMinotari::from(1_000));
         assert_eq!(totals.immature, MicroMinotari::from(9_000 + 5_000));
         assert_eq!(totals.unavailable, MicroMinotari::from(9_000 + 5_000));
+    }
+
+    /// Read back the `(status, locked_by_request_id)` pair for an output.
+    fn output_lock_state(conn: &Connection, output_id: i64) -> (String, Option<String>) {
+        conn.query_row(
+            "SELECT status, locked_by_request_id FROM outputs WHERE id = :id",
+            named_params! { ":id": output_id },
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read output lock state")
+    }
+
+    fn only_output_id(conn: &Connection, account_id: i64) -> i64 {
+        conn.query_row(
+            "SELECT id FROM outputs WHERE account_id = :account_id",
+            named_params! { ":account_id": account_id },
+            |row| row.get(0),
+        )
+        .expect("read output id")
+    }
+
+    #[test]
+    fn lock_output_rejects_an_output_that_is_no_longer_unspent() {
+        // The conditional UPDATE matches no row when the output has already been
+        // spent. Reporting success there would hand the caller a UTXO that is
+        // gone, so it must be an error.
+        let temp = tempdir().expect("temp dir");
+        let pool = init_db(temp.path().join("lock_conflict.db")).expect("init db");
+        let conn = pool.get().expect("conn");
+        let account_id = create_test_account(&conn);
+
+        insert_synthetic_output(&conn, account_id, 1, 1_000, 50, true, OutputStatus::Spent, 0);
+        let output_id = only_output_id(&conn, account_id);
+
+        let err = lock_output(&conn, output_id, "req-1", Utc::now()).expect_err("spent output cannot be locked");
+        assert!(
+            matches!(&err, WalletDbError::OutputLockConflict { output_id: id, request_id } if *id == output_id && request_id == "req-1"),
+            "expected OutputLockConflict, got: {err}"
+        );
+
+        // The losing request must not have stamped its id onto the row.
+        let (status, locked_by) = output_lock_state(&conn, output_id);
+        assert_eq!(status, OutputStatus::Spent.to_string());
+        assert_eq!(locked_by, None);
+    }
+
+    #[test]
+    fn only_one_request_can_lock_an_output() {
+        // Two requests racing for the same UTXO: the first wins, the second is
+        // told it lost rather than being allowed to believe it owns the output.
+        let temp = tempdir().expect("temp dir");
+        let pool = init_db(temp.path().join("lock_race.db")).expect("init db");
+        let conn = pool.get().expect("conn");
+        let account_id = create_test_account(&conn);
+
+        insert_synthetic_output(&conn, account_id, 1, 1_000, 50, true, OutputStatus::Unspent, 0);
+        let output_id = only_output_id(&conn, account_id);
+
+        lock_output(&conn, output_id, "req-winner", Utc::now()).expect("first lock succeeds");
+        let err = lock_output(&conn, output_id, "req-loser", Utc::now()).expect_err("second lock is refused");
+        assert!(matches!(err, WalletDbError::OutputLockConflict { .. }), "got: {err}");
+
+        // Ownership still belongs to the winner.
+        let (status, locked_by) = output_lock_state(&conn, output_id);
+        assert_eq!(status, OutputStatus::Locked.to_string());
+        assert_eq!(locked_by.as_deref(), Some("req-winner"));
+    }
+
+    #[test]
+    fn a_lock_conflict_rolls_back_the_whole_reservation() {
+        // Callers lock a set of outputs inside one write transaction. If any
+        // single lock loses its race the transaction must not commit, otherwise
+        // the caller gets a half-reserved selection it will still try to spend.
+        let temp = tempdir().expect("temp dir");
+        let pool = init_db(temp.path().join("lock_rollback.db")).expect("init db");
+        let mut conn = pool.get().expect("conn");
+        let account_id = create_test_account(&conn);
+
+        insert_synthetic_output(&conn, account_id, 1, 1_000, 50, true, OutputStatus::Unspent, 0);
+        insert_synthetic_output(&conn, account_id, 2, 2_000, 50, true, OutputStatus::Spent, 0);
+        let mut ids: Vec<i64> = conn
+            .prepare("SELECT id FROM outputs WHERE account_id = :account_id ORDER BY id")
+            .expect("prepare")
+            .query_map(named_params! { ":account_id": account_id }, |row| row.get(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("collect ids");
+        ids.sort_unstable();
+        let (unspent_id, spent_id) = (ids[0], ids[1]);
+
+        let transaction = conn.transaction().expect("begin");
+        lock_output(&transaction, unspent_id, "req-1", Utc::now()).expect("first output locks");
+        lock_output(&transaction, spent_id, "req-1", Utc::now()).expect_err("second output is already spent");
+        drop(transaction); // no commit → rollback
+
+        let (status, locked_by) = output_lock_state(&conn, unspent_id);
+        assert_eq!(
+            status,
+            OutputStatus::Unspent.to_string(),
+            "the successful lock must roll back with the failed one"
+        );
+        assert_eq!(locked_by, None);
     }
 }

--- a/minotari/src/transactions/fund_locker.rs
+++ b/minotari/src/transactions/fund_locker.rs
@@ -81,14 +81,18 @@ pub fn lock_expiry_at(now: DateTime<Utc>, seconds_to_lock_utxos: u64) -> Result<
 
 /// Global mutex that serializes all [`FundLocker::lock`] calls.
 ///
-/// The idempotency check and UTXO selection are not atomic at the database level;
-/// without this mutex two concurrent requests could both pass the idempotency
-/// check, select the same set of "unspent" outputs, and then race to lock them.
+/// Without it two concurrent requests in this process could both pass the
+/// idempotency check, select the same set of "unspent" outputs, and then race to
+/// lock them. Serialising the critical section (idempotency check → UTXO
+/// selection → pending-transaction creation → output locking) eliminates the
+/// race described in <https://github.com/anomalyco/minotari-cli/issues/125>.
 ///
-/// The mutex ensures that only one thread executes the critical section
-/// (idempotency check → UTXO selection → pending-transaction creation →
-/// output locking) at a time, eliminating the race condition described in
-/// <https://github.com/anomalyco/minotari-cli/issues/125>.
+/// This mutex is **process-local**, so it is not on its own sufficient: a second
+/// CLI invocation running against the same database file has its own copy. The
+/// cross-process guarantee comes from doing the selection and the locking inside
+/// one `BEGIN IMMEDIATE` transaction (see [`FundLocker::lock`]), backed by the
+/// conditional update in [`db::lock_output`], which refuses to reserve an output
+/// that is no longer unspent.
 static FUND_LOCK_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Manages temporary locking of UTXOs during transaction construction.
@@ -274,16 +278,48 @@ impl FundLocker {
             return Ok(response);
         }
 
-        let input_selector = InputSelector::new(account_id, confirmation_window);
-        let utxo_selection =
-            input_selector.fetch_unspent_outputs(&conn, amount, num_outputs, fee_per_gram, estimated_output_size)?;
-
         // BEGIN IMMEDIATE: acquire the write lock up front rather than upgrading
         // a read->write inside the transaction. Under concurrent writers in WAL
         // mode (e.g. the background unlocker task), a deferred transaction can
         // dead-lock with SQLITE_BUSY_SNAPSHOT — surfaced as "database is locked"
         // — which busy_timeout will not retry.
+        //
+        // Taking the write lock *before* selecting outputs is what makes the
+        // selection trustworthy across processes. `FUND_LOCK_MUTEX` only
+        // serialises threads in this process; a second CLI invocation or the
+        // daemon's own scan loop is a different process entirely. Holding the
+        // database's single write lock for the whole select → lock sequence is
+        // the only thing that stops another writer from spending or reserving
+        // one of these outputs in between.
         let transaction = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+
+        // Re-check idempotency once more inside the write transaction: a
+        // concurrent writer may have created the pending transaction after our
+        // check above but before we acquired the write lock.
+        if let Some(idempotency_key_str) = &idempotency_key
+            && let Some(response) = db::find_pending_transaction_locked_funds_by_idempotency_key(
+                &transaction,
+                idempotency_key_str,
+                account_id,
+            )?
+        {
+            info!(
+                target: "audit",
+                idempotency_key = idempotency_key_str.as_str();
+                "Found existing pending transaction lock (write-transaction re-check)"
+            );
+            return Ok(response);
+        }
+
+        let input_selector = InputSelector::new(account_id, confirmation_window);
+        let utxo_selection = input_selector.fetch_unspent_outputs(
+            &transaction,
+            amount,
+            num_outputs,
+            fee_per_gram,
+            estimated_output_size,
+        )?;
+
         // Already validated above; `lock_expiry_at` is total, so a surprising
         // value returns an error rather than panicking under the held mutex.
         let expires_at = lock_expiry_at(Utc::now(), seconds_to_lock_utxos)?;
@@ -299,6 +335,11 @@ impl FundLocker {
             expires_at,
         )?;
 
+        // Each lock is a conditional `Unspent → Locked` update. Under the write
+        // lock taken above these cannot fail, but the check is not redundant: if
+        // one ever does, `?` propagates before `commit()` and the whole
+        // reservation — pending transaction included — rolls back, rather than
+        // returning UTXOs this caller does not own.
         for utxo in &utxo_selection.utxos {
             db::lock_output(&transaction, utxo.id, &pending_tx_id, expires_at)?;
         }
@@ -601,6 +642,115 @@ mod tests {
         // Both should succeed (no double-spend errors) and select at least one UTXO
         assert!(!r_a.utxos.is_empty(), "A got UTXOs");
         assert!(!r_b.utxos.is_empty(), "B got UTXOs");
+    }
+
+    #[test]
+    fn locked_utxos_are_committed_as_locked_and_are_not_selectable_again() {
+        // The result the caller receives must match what is durably reserved in
+        // the database: every returned UTXO is LOCKED under this request's id,
+        // and no later call can select it again.
+        let (pool, account_id, _temp) = setup_test_env(2, 1_000_000);
+        let locker = FundLocker::new(pool.clone());
+
+        let first = locker
+            .lock(
+                account_id,
+                MicroMinotari(100_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+            .expect("first lock");
+
+        // The seeded outputs have distinct values, so value identifies the row.
+        let conn = pool.get().expect("conn");
+        let locked_values: HashSet<i64> = conn
+            .prepare("SELECT value FROM outputs WHERE status = 'LOCKED' AND locked_by_request_id IS NOT NULL")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, i64>(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("collect");
+
+        assert_eq!(
+            locked_values.len(),
+            first.utxos.len(),
+            "exactly the returned UTXOs should be reserved",
+        );
+        for utxo in &first.utxos {
+            assert!(
+                locked_values.contains(&(utxo.value().as_u64() as i64)),
+                "returned UTXO is not LOCKED in the database",
+            );
+        }
+
+        // A second lock must pick from what is left, never from the reserved set.
+        let second = locker
+            .lock(
+                account_id,
+                MicroMinotari(100_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+            .expect("second lock");
+        let first_hashes: HashSet<FixedHash> = first.utxos.iter().map(|u| u.output_hash()).collect();
+        for utxo in &second.utxos {
+            assert!(
+                !first_hashes.contains(&utxo.output_hash()),
+                "second lock handed back an already-reserved UTXO",
+            );
+        }
+    }
+
+    #[test]
+    fn a_failed_lock_leaves_no_pending_transaction_behind() {
+        // Selection happens inside the write transaction, so when it fails
+        // (here: nothing left to select) nothing at all is committed.
+        let (pool, account_id, _temp) = setup_test_env(1, 1_000_000);
+        let locker = FundLocker::new(pool.clone());
+
+        locker
+            .lock(
+                account_id,
+                MicroMinotari(500_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                None,
+                3600,
+                100,
+            )
+            .expect("first lock consumes the only UTXO");
+
+        locker
+            .lock(
+                account_id,
+                MicroMinotari(500_000),
+                1,
+                MicroMinotari(0),
+                Some(1000),
+                Some("doomed-key".to_string()),
+                3600,
+                100,
+            )
+            .expect_err("no spendable UTXOs remain");
+
+        let conn = pool.get().expect("conn");
+        let doomed: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pending_transactions WHERE idempotency_key = :key",
+                named_params! { ":key": "doomed-key" },
+                |row| row.get(0),
+            )
+            .expect("count pending transactions");
+        assert_eq!(doomed, 0, "a failed lock must not leave a pending transaction");
     }
 
     // -----------------------------------------------------------------------

--- a/minotari/src/transactions/manager.rs
+++ b/minotari/src/transactions/manager.rs
@@ -59,6 +59,7 @@ use chrono::Utc;
 use log::{error, info, warn};
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::Connection;
 use tari_common::configuration::Network;
 use tari_common_types::types::FixedHash;
 use tari_common_types::{tari_address::TariAddressFeatures, transaction::TxId};
@@ -320,18 +321,23 @@ impl TransactionSender {
         Ok(())
     }
 
+    /// Selects UTXOs covering the requested amount plus fees.
+    ///
+    /// Takes the connection from the caller rather than pulling a fresh one from
+    /// the pool: the selection is only meaningful when it runs inside the same
+    /// write transaction that goes on to lock the chosen outputs.
     fn create_utxo_selection(
         &self,
+        connection: &Connection,
         processed_transaction: &ProcessedTransaction,
     ) -> Result<UtxoSelection, anyhow::Error> {
-        let connection = self.get_connection()?;
         let amount = processed_transaction.recipient.amount;
         let num_outputs = 1;
         let estimated_output_size = None;
 
         let input_selector = InputSelector::new(self.account.id, self.confirmation_window);
         let utxo_selection = input_selector.fetch_unspent_outputs(
-            &connection,
+            connection,
             amount,
             num_outputs,
             self.fee_per_gram,
@@ -344,15 +350,23 @@ impl TransactionSender {
         &self,
         processed_transaction: &mut ProcessedTransaction,
     ) -> Result<String, anyhow::Error> {
-        let connection = self.get_connection()?;
+        let mut connection = self.get_connection()?;
         // `seconds_to_lock_utxos` is untrusted (JSON body / CLI argument), so use
         // the checked helper: `Utc::now() + Duration::seconds(..)` panics on
         // overflow. See `MAX_SECONDS_TO_LOCK_UTXOS`.
         let expires_at = lock_expiry_at(Utc::now(), processed_transaction.seconds_to_lock_utxos)?;
-        let utxo_selection = self.create_utxo_selection(processed_transaction)?;
+
+        // BEGIN IMMEDIATE takes the database's write lock before we look at any
+        // output, so nothing else — another CLI process, the daemon's scan loop,
+        // the unlocker — can spend or reserve one of the selected UTXOs between
+        // selection and locking. Without it the selection is a stale read and
+        // `lock_output`'s conditional update loses the race.
+        let transaction = connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+
+        let utxo_selection = self.create_utxo_selection(&transaction, processed_transaction)?;
 
         let pending_tx_id = db::create_pending_transaction(
-            &connection,
+            &transaction,
             &processed_transaction.idempotency_key,
             self.account.id,
             utxo_selection.requires_change_output,
@@ -362,9 +376,14 @@ impl TransactionSender {
             expires_at,
         )?;
 
+        // A failed lock means the output is no longer ours to reserve; `?` skips
+        // the commit below so the pending transaction and every lock taken so
+        // far roll back together.
         for utxo in &utxo_selection.utxos {
-            db::lock_output(&connection, utxo.id, &pending_tx_id, expires_at)?;
+            db::lock_output(&transaction, utxo.id, &pending_tx_id, expires_at)?;
         }
+
+        transaction.commit()?;
 
         if processed_transaction.selected_utxos.is_empty() {
             processed_transaction.selected_utxos = utxo_selection.utxos.clone();


### PR DESCRIPTION
Description
---
lock_output discards its compare-and-swap result (db/outputs.rs:515-547) — the WHERE ... AND status = :unspent is correct, but rows-affected is thrown away and it returns Ok(()) on 0 rows. FundLocker selects candidates outside the write transaction, and the mutex is process-local, so daemon + concurrent CLI hand back UTXOs the caller
doesn't own.