### PR TITLE
fix: lock idenpotency

### DIFF
--- a/minotari/migrations/00032-bind_idempotency_key_to_request/up.sql
+++ b/minotari/migrations/00032-bind_idempotency_key_to_request/up.sql
@@ -1,0 +1,14 @@
+-- Bind idempotency keys to the operation and request body that issued them.
+--
+-- A key on its own only says "this is a retry"; it does not say a retry *of
+-- what*. Storing the operation and a fingerprint of the request lets the fund
+-- locker refuse to hand a cached UTXO reservation to a replay that carries
+-- different recipients, a different amount, or that arrives at a different
+-- endpoint entirely.
+--
+-- Rows written before this migration have no recorded scope. The empty string
+-- is used as that "unknown" marker: it can never equal a real fingerprint (a
+-- fingerprint is always 64 hex characters) or a real operation name, so a
+-- legacy row can only ever be reported as a conflict, never replayed onto.
+ALTER TABLE pending_transactions ADD COLUMN operation TEXT NOT NULL DEFAULT '';
+ALTER TABLE pending_transactions ADD COLUMN request_hash TEXT NOT NULL DEFAULT '';

--- a/minotari/src/api/accounts/burn.rs
+++ b/minotari/src/api/accounts/burn.rs
@@ -59,6 +59,11 @@ pub struct BurnFundsRequest {
     pub payment_id: Option<String>,
 
     /// Optional idempotency key to prevent duplicate burn requests.
+    ///
+    /// The key is bound to this burn's parameters and to the burn operation
+    /// itself, so a key issued elsewhere (for example at `lock_funds`) cannot be
+    /// redeemed here, and reusing a burn key with different parameters is
+    /// rejected with 409 Conflict.
     pub idempotency_key: Option<String>,
 
     /// Seconds to lock input UTXOs (default: 86400 = 24 h, max: 31536000 = 365 days).
@@ -121,6 +126,7 @@ pub struct BurnFundsResponse {
         (status = 200, description = "Burn transaction broadcast successfully", body = BurnFundsResponse),
         (status = 400, description = "Invalid request parameters", body = ApiError),
         (status = 404, description = "Account not found", body = ApiError),
+        (status = 409, description = "Idempotency key reused for a different request", body = ApiError),
         (status = 500, description = "Burn failed", body = ApiError),
     ),
     params(

--- a/minotari/src/api/accounts/fund_lock.rs
+++ b/minotari/src/api/accounts/fund_lock.rs
@@ -19,7 +19,8 @@ use crate::{
     log::mask_amount,
     transactions::{
         fund_locker::{FundLocker, MAX_SECONDS_TO_LOCK_UTXOS, validate_seconds_to_lock},
-        one_sided_transaction::{OneSidedTransaction, Recipient},
+        idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint},
+        one_sided_transaction::{OneSidedTransaction, Recipient, unsigned_transaction_binding},
     },
 };
 
@@ -105,9 +106,13 @@ pub struct LockFundsRequest {
 
     /// Optional idempotency key to prevent duplicate requests.
     ///
-    /// If provided, subsequent requests with the same key will return the
-    /// cached result from the original request rather than locking additional
-    /// funds.
+    /// If provided, a later request with the same key returns the cached result
+    /// from the original request rather than locking additional funds.
+    ///
+    /// The key is bound to this request: reusing it with any field changed, or
+    /// at a different endpoint, is rejected with 409 Conflict instead of
+    /// returning the original lock. A key whose transaction has completed or
+    /// expired cannot be reused either.
     pub idempotency_key: Option<String>,
 
     /// Number of confirmations required before spending locked UTXOs.
@@ -200,8 +205,10 @@ pub struct CreateTransactionRequest {
 
     /// Optional idempotency key to prevent duplicate transactions.
     ///
-    /// If the same key is used in multiple requests, subsequent requests will
-    /// return the original transaction rather than creating a new one.
+    /// Reusing the key returns the original transaction rather than creating a
+    /// new one. The key is bound to the recipients, amounts and payment ids
+    /// below: a request that reuses the key with a different recipient list is
+    /// rejected with 409 Conflict, never served from the original lock.
     idempotency_key: Option<String>,
 
     #[schema(schema_with = confirmation_window_schema)]
@@ -259,6 +266,7 @@ pub struct CreateTransactionRequest {
         (status = 200, description = "Funds locked successfully", body = LockFundsResult),
         (status = 400, description = "Bad request", body = ApiError),
         (status = 404, description = "Account not found", body = ApiError),
+        (status = 409, description = "Idempotency key reused for a different request", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
     params(
@@ -299,6 +307,24 @@ pub async fn api_lock_funds(
 
         let lock_amount = FundLocker::new(pool);
         let confirmation_window = body.confirmation_window.unwrap_or(default_confirmations);
+        // Every field below changes which UTXOs get reserved or for how long, so
+        // all of them are bound to the key: a replay that alters any of them is
+        // a different request and must not inherit this reservation.
+        let idempotency = IdempotencyBinding::new(
+            body.idempotency_key,
+            IdempotencyOperation::LockFunds,
+            RequestFingerprint::new(IdempotencyOperation::LockFunds)
+                .field("account_id", account.id.to_le_bytes())
+                .field("amount", body.amount.as_u64().to_le_bytes())
+                .field("num_outputs", (num_outputs as u64).to_le_bytes())
+                .field("fee_per_gram", fee_per_gram.as_u64().to_le_bytes())
+                .optional_field(
+                    "estimated_output_size",
+                    body.estimated_output_size.map(|s| (s as u64).to_le_bytes()),
+                )
+                .field("seconds_to_lock_utxos", seconds_to_lock_utxos.to_le_bytes())
+                .field("confirmation_window", confirmation_window.to_le_bytes()),
+        );
         lock_amount
             .lock(
                 account.id,
@@ -306,11 +332,11 @@ pub async fn api_lock_funds(
                 num_outputs,
                 fee_per_gram,
                 body.estimated_output_size,
-                body.idempotency_key,
+                idempotency,
                 seconds_to_lock_utxos,
                 confirmation_window,
             )
-            .map_err(|e| ApiError::FailedToLockFunds(e.to_string()))
+            .map_err(|e| ApiError::from_transaction_error(e, ApiError::FailedToLockFunds))
     })
     .await
     .map_err(|e| ApiError::InternalServerError(format!("Task join error: {}", e)))??;
@@ -382,6 +408,7 @@ pub async fn api_lock_funds(
         (status = 200, description = "Unsigned transaction created successfully", body = JsonValue),
         (status = 400, description = "Bad request", body = ApiError),
         (status = 404, description = "Account not found", body = ApiError),
+        (status = 409, description = "Idempotency key reused for a different request", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
     params(
@@ -434,6 +461,17 @@ pub async fn api_create_unsigned_transaction(
         let estimated_output_size = None;
 
         let confirmation_window = body.confirmation_window.unwrap_or(default_confirmations);
+        // Bind the key to the recipients this request names. A replay carrying
+        // different recipients is rejected here rather than being handed the
+        // original request's locked UTXOs to pay them out of.
+        let idempotency = unsigned_transaction_binding(
+            body.idempotency_key,
+            account.id,
+            &recipients,
+            fee_per_gram,
+            seconds_to_lock_utxos,
+            confirmation_window,
+        );
         let lock_amount = FundLocker::new(pool.clone());
         let locked_funds = lock_amount
             .lock(
@@ -442,11 +480,11 @@ pub async fn api_create_unsigned_transaction(
                 num_outputs,
                 fee_per_gram,
                 estimated_output_size,
-                body.idempotency_key,
+                idempotency,
                 seconds_to_lock_utxos,
                 confirmation_window,
             )
-            .map_err(|e| ApiError::FailedToLockFunds(e.to_string()))?;
+            .map_err(|e| ApiError::from_transaction_error(e, ApiError::FailedToLockFunds))?;
         let one_sided_tx = OneSidedTransaction::new(pool, network, password);
         one_sided_tx
             .create_unsigned_transaction(&account, locked_funds, recipients, fee_per_gram)

--- a/minotari/src/api/error.rs
+++ b/minotari/src/api/error.rs
@@ -45,7 +45,10 @@ use serde_json::json;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use crate::{db::WalletDbError, transactions::fund_locker::InvalidLockDuration};
+use crate::{
+    db::WalletDbError,
+    transactions::{fund_locker::InvalidLockDuration, idempotency::IdempotencyConflict},
+};
 
 /// Represents all possible errors returned by the REST API.
 ///
@@ -141,6 +144,22 @@ pub enum ApiError {
     #[error("{0}")]
     BadRequest(String),
 
+    /// The request conflicts with something the wallet has already recorded.
+    ///
+    /// Returned when an idempotency key is replayed with a different operation
+    /// or a different request body, or when it belongs to a transaction that is
+    /// already completed or no longer active. Returns HTTP 409 Conflict.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///   "error": "idempotency key 'abc' was already used for a different unsigned transaction request; a key may only be retried with the exact request that created it"
+    /// }
+    /// ```
+    #[error("{0}")]
+    Conflict(String),
+
     /// Failed to lock funds for a transaction.
     ///
     /// This typically occurs when there are insufficient available funds
@@ -188,6 +207,31 @@ pub enum ApiError {
 impl From<WalletDbError> for ApiError {
     fn from(err: WalletDbError) -> Self {
         ApiError::DbError(err.to_string())
+    }
+}
+
+impl ApiError {
+    /// Converts a fund-moving failure into an API error.
+    ///
+    /// An [`IdempotencyConflict`] anywhere in the chain is the client replaying
+    /// a key that does not belong to this request — a 409, not a 500. Routing
+    /// it through `fallback` would report a server fault and invite the client
+    /// to retry the very request that was just refused.
+    pub fn from_transaction_error(err: anyhow::Error, fallback: impl FnOnce(String) -> ApiError) -> ApiError {
+        match err.downcast::<IdempotencyConflict>() {
+            Ok(conflict) => ApiError::Conflict(conflict.to_string()),
+            Err(err) => fallback(err.to_string()),
+        }
+    }
+}
+
+/// Converts an idempotency conflict into a client error.
+///
+/// The key names a request the wallet has already seen and this is not it, so
+/// 409 Conflict is the honest status: retrying unchanged will never succeed.
+impl From<IdempotencyConflict> for ApiError {
+    fn from(err: IdempotencyConflict) -> Self {
+        ApiError::Conflict(err.to_string())
     }
 }
 
@@ -242,6 +286,7 @@ impl From<serde_json::Error> for ApiError {
 /// | `AccountNotFound` | 404 |
 /// | `NotFound` | 404 |
 /// | `BadRequest` | 400 |
+/// | `Conflict` | 409 |
 /// | `FailedToLockFunds` | 500 |
 /// | `FailedCreateUnsignedTx` | 500 |
 impl IntoResponse for ApiError {
@@ -266,6 +311,10 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(msg) => {
                 warn!(message = msg.as_str(); "API: Bad Request");
                 (StatusCode::BAD_REQUEST, msg.clone())
+            },
+            ApiError::Conflict(msg) => {
+                warn!(target: "audit", message = msg.as_str(); "API: Conflict");
+                (StatusCode::CONFLICT, msg.clone())
             },
             ApiError::FailedToLockFunds(e) => {
                 error!(target: "audit", error = e.as_str(); "API: Failed to lock funds");

--- a/minotari/src/db/mod.rs
+++ b/minotari/src/db/mod.rs
@@ -84,10 +84,11 @@ pub use outputs::{
 
 mod pending_transactions;
 pub use pending_transactions::{
-    PendingTransaction, cancel_pending_transactions_by_ids, check_if_transaction_is_expired_by_idempotency_key,
-    check_if_transaction_was_already_completed_by_idempotency_key, create_pending_transaction,
-    find_expired_pending_transactions, find_pending_transaction_by_idempotency_key,
-    find_pending_transaction_locked_funds_by_idempotency_key, update_pending_transaction_status,
+    PendingTransaction, PendingTransactionRecord, cancel_pending_transactions_by_ids,
+    check_if_transaction_is_expired_by_idempotency_key, check_if_transaction_was_already_completed_by_idempotency_key,
+    create_pending_transaction, find_expired_pending_transactions, find_pending_transaction_by_idempotency_key,
+    find_pending_transaction_record_by_idempotency_key, locked_funds_for_pending_transaction,
+    update_pending_transaction_status,
 };
 
 mod completed_transactions;

--- a/minotari/src/db/pending_transactions.rs
+++ b/minotari/src/db/pending_transactions.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use crate::db::error::{WalletDbError, WalletDbResult};
 use crate::log::mask_amount;
+use crate::transactions::idempotency::IdempotencyBinding;
 use crate::{
     api::types::LockFundsResult, db::outputs::fetch_outputs_by_lock_request_id, models::PendingTransactionStatus,
 };
@@ -25,10 +26,18 @@ pub struct PendingTransaction {
     pub created_at: DateTime<Utc>,
 }
 
+/// Creates the pending transaction that owns a UTXO reservation.
+///
+/// `binding` records *what* the key was issued for: its operation and a
+/// fingerprint of the originating request. Both are persisted so a later replay
+/// of `idempotency_key` can be checked against them rather than being handed
+/// this reservation on the strength of the key alone — see
+/// [`crate::transactions::idempotency`].
 #[allow(clippy::too_many_arguments)]
 pub fn create_pending_transaction(
     conn: &Connection,
     idempotency_key: &str,
+    binding: &IdempotencyBinding,
     account_id: i64,
     requires_change_output: bool,
     total_value: MicroMinotari,
@@ -40,6 +49,7 @@ pub fn create_pending_transaction(
         target: "audit",
         account_id = account_id,
         idempotency_key = idempotency_key,
+        operation = binding.operation().as_str(),
         total_value = &*mask_amount(total_value);
         "DB: Creating pending transaction"
     );
@@ -58,6 +68,8 @@ pub fn create_pending_transaction(
         INSERT INTO pending_transactions (
             id,
             idempotency_key,
+            operation,
+            request_hash,
             account_id,
             status,
             requires_change_output,
@@ -69,6 +81,8 @@ pub fn create_pending_transaction(
         VALUES (
             :id,
             :key,
+            :operation,
+            :request_hash,
             :acc_id,
             :status,
             :change,
@@ -81,6 +95,8 @@ pub fn create_pending_transaction(
         named_params! {
             ":id": id,
             ":key": idempotency_key,
+            ":operation": binding.operation().as_str(),
+            ":request_hash": binding.request_hash(),
             ":acc_id": account_id,
             ":status": status_pending,
             ":change": requires_change_output,
@@ -160,29 +176,60 @@ pub fn update_pending_transaction_status(
     Ok(())
 }
 
-pub fn find_pending_transaction_locked_funds_by_idempotency_key(
+/// Everything the fund locker needs to decide what an idempotency key may do.
+///
+/// Deliberately carries the row's `status`, `operation` and `request_hash` as
+/// well as the reservation itself: whether a replay may be served is a decision
+/// about all four together, and a lookup that filtered on status or scope in SQL
+/// would report "no such key" for a key that does exist under a different
+/// scope — which is exactly the case that must be rejected loudly.
+pub struct PendingTransactionRecord {
+    /// The pending transaction's id, which is also the lock request id.
+    pub id: String,
+    pub status: PendingTransactionStatus,
+    /// The operation this key was issued for; empty for rows written before
+    /// idempotency keys were scoped.
+    pub operation: String,
+    /// Fingerprint of the originating request; empty for pre-scoping rows.
+    pub request_hash: String,
+    pub requires_change_output: bool,
+    pub total_value: MicroMinotari,
+    pub fee_without_change: MicroMinotari,
+    pub fee_with_change: MicroMinotari,
+}
+
+/// Looks up the pending transaction for an idempotency key, whatever its state.
+///
+/// Returns rows in *any* status, because a completed or expired key must
+/// produce a conflict rather than silently falling through to a fresh
+/// reservation under a key the wallet has already spent.
+pub fn find_pending_transaction_record_by_idempotency_key(
     conn: &Connection,
     idempotency_key: &str,
     account_id: i64,
-) -> WalletDbResult<Option<LockFundsResult>> {
-    let status_pending = PendingTransactionStatus::Pending.to_string();
-
+) -> WalletDbResult<Option<PendingTransactionRecord>> {
     let mut stmt = conn.prepare_cached(
         r#"
         SELECT
             id,
+            status,
+            operation,
+            request_hash,
             requires_change_output,
             total_value,
             fee_without_change,
             fee_with_change
         FROM pending_transactions
-        WHERE idempotency_key = :key AND account_id = :acc_id AND status = :status
+        WHERE idempotency_key = :key AND account_id = :acc_id
         "#,
     )?;
 
     #[derive(Deserialize)]
-    struct LockFundsRow {
+    struct PendingTransactionRow {
         id: String,
+        status: String,
+        operation: String,
+        request_hash: String,
         requires_change_output: bool,
         total_value: i64,
         fee_without_change: i64,
@@ -192,16 +239,18 @@ pub fn find_pending_transaction_locked_funds_by_idempotency_key(
     let rows = stmt.query(named_params! {
         ":key": idempotency_key,
         ":acc_id": account_id,
-        ":status": status_pending
     })?;
 
-    let row = from_rows::<LockFundsRow>(rows).next().transpose()?;
+    let row = from_rows::<PendingTransactionRow>(rows).next().transpose()?;
 
     match row {
         Some(row) => {
-            let utxos = fetch_outputs_by_lock_request_id(conn, &row.id)?;
-            Ok(Some(LockFundsResult {
-                utxos: utxos.into_iter().map(|db_out| db_out.output).collect(),
+            let status = PendingTransactionStatus::from_str(&row.status).map_err(WalletDbError::Decoding)?;
+            Ok(Some(PendingTransactionRecord {
+                id: row.id,
+                status,
+                operation: row.operation,
+                request_hash: row.request_hash,
                 requires_change_output: row.requires_change_output,
                 total_value: MicroMinotari::from(row.total_value as u64),
                 fee_without_change: MicroMinotari::from(row.fee_without_change as u64),
@@ -210,6 +259,25 @@ pub fn find_pending_transaction_locked_funds_by_idempotency_key(
         },
         None => Ok(None),
     }
+}
+
+/// Rebuilds the [`LockFundsResult`] a pending transaction is currently holding.
+///
+/// Only meaningful for a record whose scope has already been checked against the
+/// caller's binding; see
+/// [`FundLocker::lock`](crate::transactions::fund_locker::FundLocker::lock).
+pub fn locked_funds_for_pending_transaction(
+    conn: &Connection,
+    record: &PendingTransactionRecord,
+) -> WalletDbResult<LockFundsResult> {
+    let utxos = fetch_outputs_by_lock_request_id(conn, &record.id)?;
+    Ok(LockFundsResult {
+        utxos: utxos.into_iter().map(|db_out| db_out.output).collect(),
+        requires_change_output: record.requires_change_output,
+        total_value: record.total_value,
+        fee_without_change: record.fee_without_change,
+        fee_with_change: record.fee_with_change,
+    })
 }
 
 pub fn find_pending_transaction_by_idempotency_key(

--- a/minotari/src/main.rs
+++ b/minotari/src/main.rs
@@ -67,7 +67,8 @@ use minotari::{
     scan::{self, reorg::rollback_from_height},
     transactions::{
         fund_locker::FundLocker,
-        one_sided_transaction::{OneSidedTransaction, Recipient},
+        idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint},
+        one_sided_transaction::{OneSidedTransaction, Recipient, unsigned_transaction_binding},
     },
     utils::{self, crypto::PasswordCipher},
     webhooks::WebhookTriggerConfig,
@@ -772,6 +773,16 @@ fn handle_create_unsigned_transaction(
     let fee_per_gram = MicroMinotari(5);
     let estimated_output_size = None;
 
+    // Same binding the REST endpoint builds, so a key means the same thing
+    // whichever way the request arrives.
+    let idempotency = unsigned_transaction_binding(
+        idempotency_key,
+        account.id,
+        &recipients,
+        fee_per_gram,
+        seconds_to_lock,
+        confirmation_window,
+    );
     let lock_amount = FundLocker::new(pool.clone());
     let locked_funds = lock_amount
         .lock(
@@ -780,7 +791,7 @@ fn handle_create_unsigned_transaction(
             num_outputs,
             fee_per_gram,
             estimated_output_size,
-            idempotency_key,
+            idempotency,
             seconds_to_lock,
             confirmation_window,
         )
@@ -809,17 +820,38 @@ fn handle_lock_funds(
     let conn = pool.get()?;
     let account =
         db::get_account_by_name(&conn, &account_name)?.ok_or_else(|| anyhow!("Account not found: {}", account_name))?;
+    let num_outputs = request.num_outputs.expect("must be present");
+    let fee_per_gram = request.fee_per_gram.expect("must be present");
+    let seconds_to_lock_utxos = request.seconds_to_lock_utxos.expect("must be present");
+    let confirmation_window = request.confirmation_window.expect("must be present");
+    // Mirrors the fingerprint built by `api_lock_funds`, so the same key and the
+    // same parameters mean the same reservation from either entry point.
+    let idempotency = IdempotencyBinding::new(
+        request.idempotency_key,
+        IdempotencyOperation::LockFunds,
+        RequestFingerprint::new(IdempotencyOperation::LockFunds)
+            .field("account_id", account.id.to_le_bytes())
+            .field("amount", request.amount.as_u64().to_le_bytes())
+            .field("num_outputs", (num_outputs as u64).to_le_bytes())
+            .field("fee_per_gram", fee_per_gram.as_u64().to_le_bytes())
+            .optional_field(
+                "estimated_output_size",
+                request.estimated_output_size.map(|s| (s as u64).to_le_bytes()),
+            )
+            .field("seconds_to_lock_utxos", seconds_to_lock_utxos.to_le_bytes())
+            .field("confirmation_window", confirmation_window.to_le_bytes()),
+    );
     let lock_amount = FundLocker::new(pool.clone());
     let result = lock_amount
         .lock(
             account.id,
             request.amount,
-            request.num_outputs.expect("must be present"),
-            request.fee_per_gram.expect("must be present"),
+            num_outputs,
+            fee_per_gram,
             request.estimated_output_size,
-            request.idempotency_key,
-            request.seconds_to_lock_utxos.expect("must be present"),
-            request.confirmation_window.expect("must be present"),
+            idempotency,
+            seconds_to_lock_utxos,
+            confirmation_window,
         )
         .map_err(|e| anyhow!("Failed to lock funds: {}", e))?;
 

--- a/minotari/src/transactions/burn/mod.rs
+++ b/minotari/src/transactions/burn/mod.rs
@@ -37,7 +37,10 @@ use tari_utilities::{ByteArray, hex::Hex};
 use crate::{
     db::{AccountRow, NewBurnProof, SqlitePool},
     models::PendingTransactionStatus,
-    transactions::fund_locker::FundLocker,
+    transactions::{
+        fund_locker::FundLocker,
+        idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint},
+    },
 };
 
 /// Result returned from a successful burn transaction build.
@@ -65,6 +68,38 @@ pub struct BurnTxParams {
     pub idempotency_key: Option<String>,
     pub seconds_to_lock: u64,
     pub confirmation_window: u64,
+}
+
+impl BurnTxParams {
+    /// Binds this burn's idempotency key to the burn it was issued for.
+    ///
+    /// A burn is irreversible, so the binding matters twice over: it stops a key
+    /// minted at `/lock_funds` from being redeemed here (which would broadcast a
+    /// burn over UTXOs the client only meant to reserve), and it stops a burn
+    /// key from being replayed with a different amount or a different L2 claim
+    /// key.
+    fn idempotency_binding(&self) -> IdempotencyBinding {
+        let operation = IdempotencyOperation::BurnFunds;
+        let fingerprint = RequestFingerprint::new(operation)
+            .field("account_id", self.account_id.to_le_bytes())
+            .field("amount", self.amount.as_u64().to_le_bytes())
+            .optional_field("claim_public_key", self.claim_public_key.as_ref().map(|k| k.to_hex()))
+            // The deployment key decides which sidechain may claim the burn, so
+            // it is part of the request even though it is a secret. Only its
+            // derived public key is hashed; the fingerprint is stored in the
+            // database and read back in error paths.
+            .optional_field(
+                "sidechain_deployment_public_key",
+                self.sidechain_deployment_key
+                    .as_ref()
+                    .map(|k| CompressedPublicKey::from_secret_key(k).to_hex()),
+            )
+            .field("fee_per_gram", self.fee_per_gram.as_u64().to_le_bytes())
+            .optional_field("payment_id", self.payment_id.as_deref())
+            .field("seconds_to_lock", self.seconds_to_lock.to_le_bytes())
+            .field("confirmation_window", self.confirmation_window.to_le_bytes());
+        IdempotencyBinding::new(self.idempotency_key.clone(), operation, fingerprint)
+    }
 }
 
 /// Builds, signs, and returns a burn transaction along with its partial proof data.
@@ -95,7 +130,7 @@ pub fn create_burn_tx(
         1,
         params.fee_per_gram,
         None,
-        params.idempotency_key,
+        params.idempotency_binding(),
         params.seconds_to_lock,
         params.confirmation_window,
     )?;

--- a/minotari/src/transactions/fund_locker.rs
+++ b/minotari/src/transactions/fund_locker.rs
@@ -19,9 +19,16 @@
 //! Lock operations support idempotency keys, allowing clients to safely retry requests
 //! without accidentally locking additional funds. If a lock request with the same
 //! idempotency key already exists, the original result is returned.
+//!
+//! A key alone is not enough to authorise that short-circuit. Every caller must
+//! supply an [`IdempotencyBinding`], which ties the key to the operation and the
+//! exact request that created the lock; a replay that does not match is rejected
+//! as an [`IdempotencyConflict`] instead of being handed the reservation. See
+//! [`crate::transactions::idempotency`] for what that prevents.
 
 use chrono::{DateTime, TimeDelta, Utc};
 use log::{info, warn};
+use rusqlite::Connection;
 use std::sync::Mutex;
 use tari_transaction_components::tari_amount::MicroMinotari;
 use thiserror::Error;
@@ -31,7 +38,11 @@ use crate::{
     api::types::LockFundsResult,
     db::{self, SqlitePool},
     log::mask_amount,
-    transactions::input_selector::InputSelector,
+    models::PendingTransactionStatus,
+    transactions::{
+        idempotency::{IdempotencyBinding, IdempotencyConflict},
+        input_selector::InputSelector,
+    },
 };
 
 /// Upper bound, in seconds, on how long UTXOs may be locked (365 days).
@@ -95,6 +106,70 @@ pub fn lock_expiry_at(now: DateTime<Utc>, seconds_to_lock_utxos: u64) -> Result<
 /// that is no longer unspent.
 static FUND_LOCK_MUTEX: Mutex<()> = Mutex::new(());
 
+/// What an idempotency key is entitled to on the current request.
+enum Replay {
+    /// Nothing is reserved under this key; select and lock UTXOs as normal.
+    Fresh,
+    /// This request is an exact retry of the one that took the reservation, so
+    /// it gets that reservation back.
+    Existing(Box<LockFundsResult>),
+}
+
+/// Decides whether `binding`'s key may short-circuit onto an existing reservation.
+///
+/// The key by itself proves nothing: it is a client-chosen string, and the
+/// stored reservation was taken for whatever request first presented it. So the
+/// stored scope is checked against this request's before any UTXO is handed
+/// back, and a key whose transaction is already completed — or expired, or
+/// cancelled — is refused outright rather than being quietly treated as a
+/// brand-new request.
+///
+/// A request without a key is always [`Replay::Fresh`]: nothing to replay onto.
+fn resolve_replay(conn: &Connection, binding: &IdempotencyBinding, account_id: i64) -> Result<Replay, anyhow::Error> {
+    let Some(key) = binding.key() else {
+        return Ok(Replay::Fresh);
+    };
+    let Some(record) = db::find_pending_transaction_record_by_idempotency_key(conn, key, account_id)? else {
+        return Ok(Replay::Fresh);
+    };
+
+    // Rejects a replay carrying different recipients or amounts, a replay
+    // arriving at a different endpoint, and — because their stored scope is the
+    // empty string — any row written before scopes were recorded.
+    binding.check_matches(&record.operation, &record.request_hash)?;
+
+    match record.status {
+        PendingTransactionStatus::Pending => {
+            info!(
+                target: "audit",
+                idempotency_key = key,
+                operation = binding.operation().as_str();
+                "Found existing pending transaction lock"
+            );
+            Ok(Replay::Existing(Box::new(db::locked_funds_for_pending_transaction(
+                conn, &record,
+            )?)))
+        },
+        // The UTXOs behind this key are already spent by a broadcast
+        // transaction. Re-locking them would build a transaction that can never
+        // confirm; handing them back would be worse.
+        PendingTransactionStatus::Completed => Err(IdempotencyConflict::AlreadyCompleted {
+            key: key.to_string(),
+            operation: binding.operation(),
+        }
+        .into()),
+        // Expired or cancelled: the reservation is gone. Falling through to a
+        // fresh selection would collide with the unique (account, key) index
+        // anyway, so say plainly why.
+        status => Err(IdempotencyConflict::NoLongerActive {
+            key: key.to_string(),
+            operation: binding.operation(),
+            status: status.to_string(),
+        }
+        .into()),
+    }
+}
+
 /// Manages temporary locking of UTXOs during transaction construction.
 ///
 /// `FundLocker` ensures that UTXOs selected for a transaction cannot be used
@@ -124,7 +199,12 @@ static FUND_LOCK_MUTEX: Mutex<()> = Mutex::new(());
 ///     1,                         // number of outputs
 ///     MicroMinotari(5),          // fee per gram
 ///     None,                      // use default output size estimate
-///     Some("unique-key".into()), // idempotency key
+///     IdempotencyBinding::new(   // key, bound to this operation and request
+///         Some("unique-key".into()),
+///         IdempotencyOperation::LockFunds,
+///         RequestFingerprint::new(IdempotencyOperation::LockFunds)
+///             .field("amount", 1_000_000u64.to_le_bytes()),
+///     ),
 ///     300,                       // lock for 5 minutes
 /// ).await?;
 ///
@@ -165,8 +245,9 @@ impl FundLocker {
     /// * `fee_per_gram` - Fee rate in MicroMinotari per gram of transaction weight
     /// * `estimated_output_size` - Optional override for output size estimation; if `None`,
     ///   uses default calculation based on standard output features
-    /// * `idempotency_key` - Optional unique key for idempotent operations; if provided and
-    ///   a matching lock exists, returns the existing result
+    /// * `idempotency` - The client's idempotency key bound to the operation and request that
+    ///   issued it. A key only returns an existing lock when the operation *and* the request
+    ///   fingerprint match what that lock was created for
     /// * `seconds_to_lock_utxos` - Duration in seconds before the lock expires;
     ///   must not exceed [`MAX_SECONDS_TO_LOCK_UTXOS`]
     ///
@@ -183,6 +264,9 @@ impl FundLocker {
     /// Returns an error if:
     /// - `seconds_to_lock_utxos` exceeds [`MAX_SECONDS_TO_LOCK_UTXOS`]
     ///   ([`InvalidLockDuration`])
+    /// - The idempotency key was already used for a different operation or a different
+    ///   request, or belongs to a transaction that is completed or no longer active
+    ///   ([`IdempotencyConflict`])
     /// - Database connection fails
     /// - Insufficient funds are available
     /// - UTXO selection fails due to serialization errors
@@ -196,7 +280,7 @@ impl FundLocker {
     ///     1,
     ///     MicroMinotari(5),
     ///     None,
-    ///     Some("tx-123".to_string()),
+    ///     binding, // an `IdempotencyBinding` built from the request
     ///     600, // 10 minute lock
     /// ).await?;
     ///
@@ -210,13 +294,14 @@ impl FundLocker {
         num_outputs: usize,
         fee_per_gram: MicroMinotari,
         estimated_output_size: Option<usize>,
-        idempotency_key: Option<String>,
+        idempotency: IdempotencyBinding,
         seconds_to_lock_utxos: u64,
         confirmation_window: u64,
     ) -> Result<LockFundsResult, anyhow::Error> {
         info!(
             target: "audit",
             account_id = account_id,
+            operation = idempotency.operation().as_str(),
             amount = &*mask_amount(amount);
             "Locking funds"
         );
@@ -230,17 +315,10 @@ impl FundLocker {
         let mut conn = self.db_pool.get()?;
         // Fast idempotency check (without the global mutex).  If the pending
         // transaction already exists we can return immediately without waiting
-        // for any concurrent `lock()` call to finish.
-        if let Some(idempotency_key_str) = &idempotency_key
-            && let Some(response) =
-                db::find_pending_transaction_locked_funds_by_idempotency_key(&conn, idempotency_key_str, account_id)?
-        {
-            info!(
-                target: "audit",
-                idempotency_key = idempotency_key_str.as_str();
-                "Found existing pending transaction lock"
-            );
-            return Ok(response);
+        // for any concurrent `lock()` call to finish.  A key that does not match
+        // the stored scope fails here, before any UTXO is looked at.
+        if let Replay::Existing(response) = resolve_replay(&conn, &idempotency, account_id)? {
+            return Ok(*response);
         }
 
         // Acquire the global mutex so that the idempotency re-check, UTXO
@@ -266,16 +344,8 @@ impl FundLocker {
         // that passed the fast-path check above may have created the pending
         // transaction while we were waiting for the lock; if so we return its
         // result rather than selecting UTXOs a second time.
-        if let Some(idempotency_key_str) = &idempotency_key
-            && let Some(response) =
-                db::find_pending_transaction_locked_funds_by_idempotency_key(&conn, idempotency_key_str, account_id)?
-        {
-            info!(
-                target: "audit",
-                idempotency_key = idempotency_key_str.as_str();
-                "Found existing pending transaction lock (re-check)"
-            );
-            return Ok(response);
+        if let Replay::Existing(response) = resolve_replay(&conn, &idempotency, account_id)? {
+            return Ok(*response);
         }
 
         // BEGIN IMMEDIATE: acquire the write lock up front rather than upgrading
@@ -296,19 +366,8 @@ impl FundLocker {
         // Re-check idempotency once more inside the write transaction: a
         // concurrent writer may have created the pending transaction after our
         // check above but before we acquired the write lock.
-        if let Some(idempotency_key_str) = &idempotency_key
-            && let Some(response) = db::find_pending_transaction_locked_funds_by_idempotency_key(
-                &transaction,
-                idempotency_key_str,
-                account_id,
-            )?
-        {
-            info!(
-                target: "audit",
-                idempotency_key = idempotency_key_str.as_str();
-                "Found existing pending transaction lock (write-transaction re-check)"
-            );
-            return Ok(response);
+        if let Replay::Existing(response) = resolve_replay(&transaction, &idempotency, account_id)? {
+            return Ok(*response);
         }
 
         let input_selector = InputSelector::new(account_id, confirmation_window);
@@ -323,10 +382,14 @@ impl FundLocker {
         // Already validated above; `lock_expiry_at` is total, so a surprising
         // value returns an error rather than panicking under the held mutex.
         let expires_at = lock_expiry_at(Utc::now(), seconds_to_lock_utxos)?;
-        let idempotency_key = idempotency_key.unwrap_or_else(|| Uuid::new_v4().to_string());
+        // No client key means no replay is possible, so any unique key will do.
+        let idempotency_key = idempotency
+            .key()
+            .map_or_else(|| Uuid::new_v4().to_string(), str::to_string);
         let pending_tx_id = db::create_pending_transaction(
             &transaction,
             &idempotency_key,
+            &idempotency,
             account_id,
             utxo_selection.requires_change_output,
             utxo_selection.total_value,
@@ -371,8 +434,12 @@ mod tests {
     #![allow(clippy::indexing_slicing)]
 
     use super::*;
-    use crate::db::{create_account, get_account_by_name, init_db, insert_scanned_tip_block};
-    use rusqlite::{Connection, named_params};
+    use crate::{
+        db::{create_account, get_account_by_name, init_db, insert_scanned_tip_block},
+        transactions::idempotency::{IdempotencyOperation, RequestFingerprint},
+    };
+    use anyhow::Error;
+    use rusqlite::named_params;
     use std::collections::HashSet;
     use tari_common_types::{
         seeds::cipher_seed::CipherSeed,
@@ -484,6 +551,52 @@ mod tests {
         (pool, account_id, temp)
     }
 
+    /// A lock-funds binding for `key` over a request identified by `amount`.
+    ///
+    /// `amount` stands in for the whole request body: two calls with the same
+    /// key and the same `amount` are retries of one request, and changing it
+    /// models a client replaying the key with a different body.
+    fn test_binding(key: Option<&str>, amount: u64) -> IdempotencyBinding {
+        scoped_test_binding(key, IdempotencyOperation::LockFunds, amount)
+    }
+
+    /// As [`test_binding`], but for a caller claiming to be a different operation.
+    fn scoped_test_binding(key: Option<&str>, operation: IdempotencyOperation, amount: u64) -> IdempotencyBinding {
+        IdempotencyBinding::new(
+            key.map(str::to_string),
+            operation,
+            RequestFingerprint::new(operation).field("amount", amount.to_le_bytes()),
+        )
+    }
+
+    /// Locks 100_000 µT under `binding`, with everything else held constant.
+    fn lock_with(pool: &SqlitePool, account_id: i64, binding: IdempotencyBinding) -> Result<LockFundsResult, Error> {
+        FundLocker::new(pool.clone()).lock(
+            account_id,
+            MicroMinotari(100_000),
+            1,
+            MicroMinotari(0),
+            Some(1000),
+            binding,
+            3600,
+            100,
+        )
+    }
+
+    /// The set of outputs currently reserved in the database, by value.
+    ///
+    /// The seeded outputs have distinct values, so a value identifies a row.
+    fn locked_values(pool: &SqlitePool) -> HashSet<i64> {
+        pool.get()
+            .expect("conn")
+            .prepare("SELECT value FROM outputs WHERE status = 'LOCKED'")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, i64>(0))
+            .expect("query")
+            .collect::<Result<_, _>>()
+            .expect("collect")
+    }
+
     // -----------------------------------------------------------------------
     // Tests
     // -----------------------------------------------------------------------
@@ -501,7 +614,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100, // confirmation_window = 100 → tip(200) − 100 = 100 ≥ mined(100)
             )
@@ -514,7 +627,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -557,7 +670,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                Some(key),
+                test_binding(Some(&key), 1),
                 3600,
                 100,
             )
@@ -570,7 +683,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                Some(key2),
+                test_binding(Some(&key2), 1),
                 3600,
                 100,
             )
@@ -618,7 +731,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -630,7 +743,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -659,7 +772,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -695,7 +808,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -723,7 +836,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -736,7 +849,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                Some("doomed-key".to_string()),
+                test_binding(Some("doomed-key"), 1),
                 3600,
                 100,
             )
@@ -808,7 +921,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 10_000_000_000_000,
                 100,
             )
@@ -828,7 +941,7 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
@@ -856,11 +969,182 @@ mod tests {
                 1,
                 MicroMinotari(0),
                 Some(1000),
-                None,
+                test_binding(None, 1),
                 3600,
                 100,
             )
             .expect("lock recovers from a poisoned mutex");
         assert!(!result.utxos.is_empty(), "lock selected UTXOs after recovery");
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency key scoping
+    // -----------------------------------------------------------------------
+
+    fn conflict(err: &Error) -> &IdempotencyConflict {
+        err.downcast_ref::<IdempotencyConflict>()
+            .unwrap_or_else(|| panic!("expected an IdempotencyConflict, got: {err}"))
+    }
+
+    #[test]
+    fn an_exact_retry_returns_the_original_reservation() {
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        let first = lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("first lock");
+        let retry = lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("retry is idempotent");
+
+        let first_hashes: HashSet<FixedHash> = first.utxos.iter().map(|u| u.output_hash()).collect();
+        let retry_hashes: HashSet<FixedHash> = retry.utxos.iter().map(|u| u.output_hash()).collect();
+        assert_eq!(first_hashes, retry_hashes, "a retry gets the same UTXOs back");
+        assert_eq!(first.total_value, retry.total_value);
+        assert_eq!(
+            locked_values(&pool).len(),
+            first.utxos.len(),
+            "a retry must not reserve anything further",
+        );
+    }
+
+    #[test]
+    fn replaying_a_key_with_a_different_request_is_rejected() {
+        // The reported attack: take a client's key, resend it with a different
+        // body, and collect the UTXOs the client reserved. The changed body must
+        // make the key unusable rather than short-circuit onto that reservation.
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        let victim = lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("victim's lock");
+        let reserved = locked_values(&pool);
+
+        let err = lock_with(&pool, account_id, test_binding(Some("k"), 2))
+            .expect_err("a replay with a different request must not be served");
+        assert!(
+            matches!(conflict(&err), IdempotencyConflict::RequestMismatch { .. }),
+            "expected a request mismatch, got: {err}",
+        );
+
+        // The victim's reservation is untouched: same rows, still locked to it.
+        assert_eq!(
+            locked_values(&pool),
+            reserved,
+            "the original lock must survive the replay"
+        );
+        let retry = lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("the victim can still retry");
+        let victim_hashes: HashSet<FixedHash> = victim.utxos.iter().map(|u| u.output_hash()).collect();
+        let retry_hashes: HashSet<FixedHash> = retry.utxos.iter().map(|u| u.output_hash()).collect();
+        assert_eq!(victim_hashes, retry_hashes);
+    }
+
+    #[test]
+    fn a_key_cannot_be_redeemed_at_a_different_operation() {
+        // A `/lock_funds` key replayed at `/burn` used to hand the burn the
+        // reserved UTXOs and destroy them.
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("lock_funds reservation");
+        let reserved = locked_values(&pool);
+
+        let err = lock_with(
+            &pool,
+            account_id,
+            scoped_test_binding(Some("k"), IdempotencyOperation::BurnFunds, 1),
+        )
+        .expect_err("a lock_funds key must not be redeemable as a burn");
+        assert!(
+            matches!(conflict(&err), IdempotencyConflict::OperationMismatch { .. }),
+            "expected an operation mismatch, got: {err}",
+        );
+        assert_eq!(locked_values(&pool), reserved, "the reservation must be untouched");
+    }
+
+    #[test]
+    fn a_completed_key_cannot_be_replayed() {
+        // Once the transaction is broadcast its inputs are spent. Replaying the
+        // key must fail rather than hand back UTXOs that no longer exist.
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("initial lock");
+        let conn = pool.get().expect("conn");
+        let pending_id: String = conn
+            .query_row(
+                "SELECT id FROM pending_transactions WHERE idempotency_key = :key",
+                named_params! { ":key": "k" },
+                |row| row.get(0),
+            )
+            .expect("pending transaction exists");
+        crate::db::update_pending_transaction_status(&conn, &pending_id, PendingTransactionStatus::Completed)
+            .expect("mark completed");
+        drop(conn);
+
+        let err = lock_with(&pool, account_id, test_binding(Some("k"), 1))
+            .expect_err("a completed key must not be replayable");
+        assert!(
+            matches!(conflict(&err), IdempotencyConflict::AlreadyCompleted { .. }),
+            "expected an already-completed conflict, got: {err}",
+        );
+    }
+
+    #[test]
+    fn an_expired_key_reports_why_instead_of_colliding() {
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("initial lock");
+        let conn = pool.get().expect("conn");
+        let pending_id: String = conn
+            .query_row(
+                "SELECT id FROM pending_transactions WHERE idempotency_key = :key",
+                named_params! { ":key": "k" },
+                |row| row.get(0),
+            )
+            .expect("pending transaction exists");
+        crate::db::update_pending_transaction_status(&conn, &pending_id, PendingTransactionStatus::Expired)
+            .expect("mark expired");
+        drop(conn);
+
+        let err =
+            lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect_err("an expired key cannot be reused");
+        assert!(
+            matches!(conflict(&err), IdempotencyConflict::NoLongerActive { .. }),
+            "expected a no-longer-active conflict, got: {err}",
+        );
+    }
+
+    #[test]
+    fn a_legacy_row_without_a_recorded_scope_is_never_replayed_onto() {
+        // Rows written before scopes existed carry empty strings. Their key must
+        // not be usable, because there is nothing to check the request against.
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        lock_with(&pool, account_id, test_binding(Some("k"), 1)).expect("initial lock");
+        let conn = pool.get().expect("conn");
+        conn.execute(
+            "UPDATE pending_transactions SET operation = '', request_hash = '' WHERE idempotency_key = :key",
+            named_params! { ":key": "k" },
+        )
+        .expect("blank the scope the way a pre-migration row would be");
+        drop(conn);
+
+        let err = lock_with(&pool, account_id, test_binding(Some("k"), 1))
+            .expect_err("a row with no recorded scope cannot be matched");
+        assert!(
+            matches!(conflict(&err), IdempotencyConflict::OperationMismatch { .. }),
+            "expected an operation mismatch, got: {err}",
+        );
+    }
+
+    #[test]
+    fn requests_without_a_key_never_share_a_reservation() {
+        // Each keyless request gets its own generated key, so two of them must
+        // select disjoint UTXOs rather than collapsing onto one reservation.
+        let (pool, account_id, _temp) = setup_test_env(3, 1_000_000);
+
+        let first = lock_with(&pool, account_id, test_binding(None, 1)).expect("first lock");
+        let second = lock_with(&pool, account_id, test_binding(None, 1)).expect("second lock");
+
+        let first_hashes: HashSet<FixedHash> = first.utxos.iter().map(|u| u.output_hash()).collect();
+        for utxo in &second.utxos {
+            assert!(
+                !first_hashes.contains(&utxo.output_hash()),
+                "a keyless request reused another request's reservation",
+            );
+        }
     }
 }

--- a/minotari/src/transactions/idempotency.rs
+++ b/minotari/src/transactions/idempotency.rs
@@ -1,0 +1,418 @@
+//! Binding idempotency keys to the request that issued them.
+//!
+//! # Why a bare key is not enough
+//!
+//! An idempotency key on its own is just a client-chosen string. Every
+//! fund-moving entry point in this wallet reaches [`FundLocker::lock`] with one,
+//! and the lock short-circuits when a pending transaction for that key already
+//! exists — handing back the UTXOs the *original* request reserved.
+//!
+//! If the key is not tied to the request that created it, that short-circuit is
+//! an attack:
+//!
+//! * **Body swap.** Replay a client's key at `/create_unsigned_transaction`
+//!   with different `recipients`. The cached lock is returned, the recipients
+//!   are taken from the *replayed* body, and the wallet builds an unsigned
+//!   transaction paying the attacker out of the victim's reserved UTXOs.
+//! * **Operation swap.** The key namespace was shared across every endpoint, so
+//!   a key issued at `/lock_funds` could be replayed at `/burn`. The burn takes
+//!   the cached lock and broadcasts a burn — irreversibly destroying funds the
+//!   client only meant to reserve.
+//!
+//! # The binding
+//!
+//! An [`IdempotencyBinding`] carries three things: the client's key, the
+//! [`IdempotencyOperation`] it was issued for, and a [`RequestFingerprint`] over
+//! every request field that determines what the wallet actually does. Both the
+//! operation and the fingerprint are stored alongside the pending transaction.
+//!
+//! On replay the stored pair is compared with the incoming one. A key may only
+//! short-circuit into a lock created by *the same operation with the same
+//! parameters*; anything else is an [`IdempotencyConflict`] (HTTP 409), never a
+//! silent hand-back of someone else's UTXOs.
+//!
+//! # Building a fingerprint
+//!
+//! Include every field that changes where the money goes or how much of it
+//! moves. Omitting one re-opens the body-swap hole for that field, so err
+//! towards including too much: the cost of an over-strict fingerprint is a
+//! client having to pick a new key, and the cost of an under-strict one is
+//! funds paid to an attacker.
+//!
+//! ```rust,ignore
+//! let binding = IdempotencyBinding::new(
+//!     body.idempotency_key,
+//!     IdempotencyOperation::LockFunds,
+//!     RequestFingerprint::new(IdempotencyOperation::LockFunds)
+//!         .field("account_id", account.id.to_le_bytes())
+//!         .field("amount", body.amount.as_u64().to_le_bytes())
+//!         .field("num_outputs", num_outputs.to_le_bytes()),
+//! );
+//! ```
+//!
+//! [`FundLocker::lock`]: crate::transactions::fund_locker::FundLocker::lock
+
+use std::fmt;
+
+use tari_crypto::{hash_domain, hashing::DomainSeparatedHasher};
+use tari_transaction_components::key_manager::wallet_types::KeyDigest;
+use thiserror::Error;
+
+hash_domain!(
+    IdempotencyDomain,
+    "com.tari.minotari_cli.idempotency_request_fingerprint",
+    1
+);
+
+/// Label separating request fingerprints from any other use of the domain.
+const REQUEST_FINGERPRINT_LABEL: &str = "request_fingerprint";
+
+/// The operation an idempotency key was issued for.
+///
+/// Stored with the pending transaction so a key minted at one endpoint cannot
+/// be redeemed at another. Without this, a `/lock_funds` key replayed at
+/// `/burn` would short-circuit onto the reserved UTXOs and broadcast a burn
+/// over them.
+///
+/// The string form is persisted, so existing variants' strings must not change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdempotencyOperation {
+    /// `POST /accounts/{name}/lock_funds` and the `lock-funds` CLI command.
+    LockFunds,
+    /// `POST /accounts/{name}/create_unsigned_transaction` and the
+    /// `create-unsigned-transaction` CLI command.
+    CreateUnsignedTransaction,
+    /// The full send flow driven by
+    /// [`TransactionSender`](crate::transactions::manager::TransactionSender).
+    SendTransaction,
+    /// `POST /accounts/{name}/burn` and the `burn-funds` CLI command.
+    BurnFunds,
+    /// Validator node registration.
+    ValidatorNodeRegistration,
+    /// Validator node exit.
+    ValidatorNodeExit,
+    /// Validator node eviction proof submission.
+    ValidatorNodeEviction,
+}
+
+impl IdempotencyOperation {
+    /// The persisted form. Changing an existing string invalidates stored rows.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            IdempotencyOperation::LockFunds => "lock_funds",
+            IdempotencyOperation::CreateUnsignedTransaction => "create_unsigned_transaction",
+            IdempotencyOperation::SendTransaction => "send_transaction",
+            IdempotencyOperation::BurnFunds => "burn_funds",
+            IdempotencyOperation::ValidatorNodeRegistration => "validator_node_registration",
+            IdempotencyOperation::ValidatorNodeExit => "validator_node_exit",
+            IdempotencyOperation::ValidatorNodeEviction => "validator_node_eviction",
+        }
+    }
+
+    /// Human-readable name used in log lines and error messages.
+    pub const fn description(self) -> &'static str {
+        match self {
+            IdempotencyOperation::LockFunds => "fund lock",
+            IdempotencyOperation::CreateUnsignedTransaction => "unsigned transaction",
+            IdempotencyOperation::SendTransaction => "transaction send",
+            IdempotencyOperation::BurnFunds => "burn",
+            IdempotencyOperation::ValidatorNodeRegistration => "validator node registration",
+            IdempotencyOperation::ValidatorNodeExit => "validator node exit",
+            IdempotencyOperation::ValidatorNodeEviction => "validator node eviction proof",
+        }
+    }
+}
+
+impl fmt::Display for IdempotencyOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A domain-separated hash over the request fields that decide what the wallet does.
+///
+/// Fields are fed in as `(name, value)` pairs and each part is length-prefixed
+/// before hashing, so no two different field lists can collide by re-splitting
+/// the same bytes: `field("a", "bc")` and `field("ab", "c")` hash differently,
+/// as do `[("a", "b"), ("c", "d")]` and `[("a", "bcd")]`.
+///
+/// The operation is mixed in at construction, so the same parameters submitted
+/// to two different endpoints never produce the same fingerprint.
+pub struct RequestFingerprint {
+    hasher: DomainSeparatedHasher<KeyDigest, IdempotencyDomain>,
+}
+
+impl RequestFingerprint {
+    /// Starts a fingerprint for `operation`.
+    pub fn new(operation: IdempotencyOperation) -> Self {
+        let fingerprint = Self {
+            hasher: DomainSeparatedHasher::new_with_label(REQUEST_FINGERPRINT_LABEL),
+        };
+        fingerprint.field("operation", operation.as_str())
+    }
+
+    /// Mixes one named request field into the fingerprint.
+    ///
+    /// Both the name and the value are length-prefixed, so the result depends on
+    /// the exact field list and not merely on the concatenated bytes.
+    #[must_use]
+    pub fn field(self, name: &str, value: impl AsRef<[u8]>) -> Self {
+        let value = value.as_ref();
+        Self {
+            hasher: self
+                .hasher
+                .chain((name.len() as u64).to_le_bytes())
+                .chain(name.as_bytes())
+                .chain((value.len() as u64).to_le_bytes())
+                .chain(value),
+        }
+    }
+
+    /// Mixes in a field that may be absent.
+    ///
+    /// An absent field is distinguished from a present-but-empty one, so
+    /// `payment_id: null` and `payment_id: ""` do not share a fingerprint.
+    #[must_use]
+    pub fn optional_field(self, name: &str, value: Option<impl AsRef<[u8]>>) -> Self {
+        match value {
+            Some(value) => self.field(name, value).field("__present", [1u8]),
+            None => self.field(name, []).field("__present", [0u8]),
+        }
+    }
+
+    /// Finishes the hash and returns it hex-encoded for storage.
+    pub fn finish(self) -> String {
+        hex::encode(self.hasher.finalize().as_ref())
+    }
+}
+
+/// An idempotency key together with the operation and request it is bound to.
+///
+/// Construct one at the request boundary and hand it to
+/// [`FundLocker::lock`](crate::transactions::fund_locker::FundLocker::lock),
+/// which enforces the binding before returning any cached lock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdempotencyBinding {
+    /// The client-supplied key, if any. When absent the caller gets a fresh
+    /// random key and no replay is possible.
+    key: Option<String>,
+    operation: IdempotencyOperation,
+    request_hash: String,
+}
+
+impl IdempotencyBinding {
+    /// Binds `key` to `operation` and the request described by `fingerprint`.
+    pub fn new(key: Option<String>, operation: IdempotencyOperation, fingerprint: RequestFingerprint) -> Self {
+        Self {
+            key,
+            operation,
+            request_hash: fingerprint.finish(),
+        }
+    }
+
+    /// The client-supplied key, if one was provided.
+    pub fn key(&self) -> Option<&str> {
+        self.key.as_deref()
+    }
+
+    /// The operation this key was issued for.
+    pub fn operation(&self) -> IdempotencyOperation {
+        self.operation
+    }
+
+    /// The hex-encoded fingerprint of the originating request.
+    pub fn request_hash(&self) -> &str {
+        &self.request_hash
+    }
+
+    /// Checks a stored `(operation, request_hash)` pair against this binding.
+    ///
+    /// Returns an error when the stored pair was written by a different
+    /// operation or a different request body — the case where returning the
+    /// cached lock would hand this caller UTXOs reserved for someone else's
+    /// request.
+    pub fn check_matches(&self, stored_operation: &str, stored_request_hash: &str) -> Result<(), IdempotencyConflict> {
+        if stored_operation != self.operation.as_str() {
+            return Err(IdempotencyConflict::OperationMismatch {
+                key: self.key_for_error(),
+                stored_operation: stored_operation.to_string(),
+                requested_operation: self.operation,
+            });
+        }
+        if stored_request_hash != self.request_hash {
+            return Err(IdempotencyConflict::RequestMismatch {
+                key: self.key_for_error(),
+                operation: self.operation,
+            });
+        }
+        Ok(())
+    }
+
+    /// The key to name in an error. Conflicts can only arise once a key was
+    /// supplied, so the fallback is unreachable in practice.
+    fn key_for_error(&self) -> String {
+        self.key.clone().unwrap_or_else(|| "<none>".to_string())
+    }
+}
+
+/// An idempotency key was replayed in a way that is not a retry of the original request.
+///
+/// Every variant is a client error: the key identifies a request the wallet has
+/// already seen, and this one is not it. Callers at a request boundary should
+/// map these to HTTP 409 Conflict.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IdempotencyConflict {
+    /// The key was issued for a different endpoint.
+    #[error(
+        "idempotency key '{key}' was already used for a '{stored_operation}' request and cannot be reused for a \
+         '{requested_operation}' request; use a new key"
+    )]
+    OperationMismatch {
+        key: String,
+        stored_operation: String,
+        requested_operation: IdempotencyOperation,
+    },
+
+    /// The key was issued for this endpoint but with different parameters.
+    #[error(
+        "idempotency key '{key}' was already used for a different {operation} request; a key may only be retried with \
+         the exact request that created it"
+    )]
+    RequestMismatch {
+        key: String,
+        operation: IdempotencyOperation,
+    },
+
+    /// The key belongs to a transaction that has already been broadcast.
+    ///
+    /// Its UTXOs are spent, so re-locking them or handing them back would
+    /// produce a transaction that can never confirm.
+    #[error("idempotency key '{key}' belongs to a {operation} request that has already been completed; use a new key")]
+    AlreadyCompleted {
+        key: String,
+        operation: IdempotencyOperation,
+    },
+
+    /// The key belongs to a lock that expired or was cancelled.
+    ///
+    /// The reservation is gone, so this cannot be served as a retry. A fresh
+    /// key gets a fresh lock.
+    #[error(
+        "idempotency key '{key}' belongs to a {operation} request that is no longer active (status {status}); use a \
+         new key"
+    )]
+    NoLongerActive {
+        key: String,
+        operation: IdempotencyOperation,
+        status: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fingerprint_of(operation: IdempotencyOperation, amount: u64, recipient: &str) -> String {
+        RequestFingerprint::new(operation)
+            .field("amount", amount.to_le_bytes())
+            .field("recipient", recipient)
+            .finish()
+    }
+
+    #[test]
+    fn identical_requests_share_a_fingerprint() {
+        assert_eq!(
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "alice"),
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "alice"),
+        );
+    }
+
+    #[test]
+    fn a_changed_field_changes_the_fingerprint() {
+        // The body-swap attack: same key, different recipient.
+        assert_ne!(
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "alice"),
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "mallory"),
+        );
+        assert_ne!(
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "alice"),
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_001, "alice"),
+        );
+    }
+
+    #[test]
+    fn the_same_request_under_a_different_operation_differs() {
+        // The operation-swap attack: a /lock_funds key replayed at /burn.
+        assert_ne!(
+            fingerprint_of(IdempotencyOperation::LockFunds, 1_000, "alice"),
+            fingerprint_of(IdempotencyOperation::BurnFunds, 1_000, "alice"),
+        );
+    }
+
+    #[test]
+    fn field_boundaries_cannot_be_shifted() {
+        // Without length prefixes these would hash the same bytes in the same
+        // order, letting an attacker move a byte from one field into the next.
+        let split = RequestFingerprint::new(IdempotencyOperation::LockFunds)
+            .field("a", "bc")
+            .finish();
+        let shifted = RequestFingerprint::new(IdempotencyOperation::LockFunds)
+            .field("ab", "c")
+            .finish();
+        assert_ne!(split, shifted);
+
+        let two_fields = RequestFingerprint::new(IdempotencyOperation::LockFunds)
+            .field("x", "ab")
+            .field("y", "cd")
+            .finish();
+        let one_field = RequestFingerprint::new(IdempotencyOperation::LockFunds)
+            .field("x", "abycd")
+            .finish();
+        assert_ne!(two_fields, one_field);
+    }
+
+    #[test]
+    fn an_absent_field_differs_from_an_empty_one() {
+        let absent = RequestFingerprint::new(IdempotencyOperation::BurnFunds)
+            .optional_field("payment_id", None::<&str>)
+            .finish();
+        let empty = RequestFingerprint::new(IdempotencyOperation::BurnFunds)
+            .optional_field("payment_id", Some(""))
+            .finish();
+        assert_ne!(absent, empty);
+    }
+
+    #[test]
+    fn a_binding_accepts_only_its_own_operation_and_request() {
+        let binding = IdempotencyBinding::new(
+            Some("key-1".to_string()),
+            IdempotencyOperation::LockFunds,
+            RequestFingerprint::new(IdempotencyOperation::LockFunds).field("amount", 1_000u64.to_le_bytes()),
+        );
+
+        binding
+            .check_matches(binding.operation().as_str(), binding.request_hash())
+            .expect("an exact retry is allowed");
+
+        assert!(matches!(
+            binding.check_matches(IdempotencyOperation::BurnFunds.as_str(), binding.request_hash()),
+            Err(IdempotencyConflict::OperationMismatch { .. }),
+        ));
+        assert!(matches!(
+            binding.check_matches(IdempotencyOperation::LockFunds.as_str(), "deadbeef"),
+            Err(IdempotencyConflict::RequestMismatch { .. }),
+        ));
+    }
+
+    #[test]
+    fn a_binding_without_a_key_still_carries_its_scope() {
+        let binding = IdempotencyBinding::new(
+            None,
+            IdempotencyOperation::BurnFunds,
+            RequestFingerprint::new(IdempotencyOperation::BurnFunds),
+        );
+        assert_eq!(binding.key(), None);
+        assert_eq!(binding.operation(), IdempotencyOperation::BurnFunds);
+        assert!(!binding.request_hash().is_empty());
+    }
+}

--- a/minotari/src/transactions/manager.rs
+++ b/minotari/src/transactions/manager.rs
@@ -93,6 +93,7 @@ use crate::{
             TransactionInput, TransactionSource,
         },
         fund_locker::lock_expiry_at,
+        idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint},
         input_selector::{InputSelector, UtxoSelection},
         one_sided_transaction::Recipient,
     },
@@ -151,6 +152,25 @@ impl ProcessedTransaction {
     /// Updates the transaction ID after the pending transaction is created.
     pub fn update_id(&mut self, id: String) {
         self.id = Some(id);
+    }
+
+    /// Binds this transaction's idempotency key to the payment it describes.
+    ///
+    /// Without the recipient in the fingerprint, replaying the key with a
+    /// different address would return this transaction's reserved UTXOs and
+    /// build a payment to whoever the replay named.
+    fn idempotency_binding(&self, account_id: i64) -> IdempotencyBinding {
+        let operation = IdempotencyOperation::SendTransaction;
+        IdempotencyBinding::new(
+            Some(self.idempotency_key.clone()),
+            operation,
+            RequestFingerprint::new(operation)
+                .field("account_id", account_id.to_le_bytes())
+                .field("recipient_address", self.recipient.address.to_base58())
+                .field("recipient_amount", self.recipient.amount.as_u64().to_le_bytes())
+                .optional_field("recipient_payment_id", self.recipient.payment_id.as_deref())
+                .field("seconds_to_lock_utxos", self.seconds_to_lock_utxos.to_le_bytes()),
+        )
     }
 }
 
@@ -368,6 +388,7 @@ impl TransactionSender {
         let pending_tx_id = db::create_pending_transaction(
             &transaction,
             &processed_transaction.idempotency_key,
+            &processed_transaction.idempotency_binding(self.account.id),
             self.account.id,
             utxo_selection.requires_change_output,
             utxo_selection.total_value,
@@ -398,13 +419,18 @@ impl TransactionSender {
     ) -> Result<String, anyhow::Error> {
         let connection = self.get_connection()?;
 
-        let response = db::find_pending_transaction_by_idempotency_key(
+        let response = db::find_pending_transaction_record_by_idempotency_key(
             &connection,
             &processed_transaction.idempotency_key,
             self.account.id,
         )?;
-        if let Some(pending_tx) = response {
-            Ok(pending_tx.id.to_string())
+        if let Some(record) = response {
+            // The key alone does not entitle this request to that reservation:
+            // it must be the same operation with the same recipient and amount.
+            processed_transaction
+                .idempotency_binding(self.account.id)
+                .check_matches(&record.operation, &record.request_hash)?;
+            Ok(record.id)
         } else {
             let pending_tx_id = self.create_pending_transaction(processed_transaction)?;
             Ok(pending_tx_id)

--- a/minotari/src/transactions/mod.rs
+++ b/minotari/src/transactions/mod.rs
@@ -73,6 +73,7 @@ pub mod burn;
 pub mod displayed_transaction_processor;
 pub mod fee_estimator;
 pub mod fund_locker;
+pub mod idempotency;
 pub mod input_selector;
 pub mod manager;
 pub mod monitor;

--- a/minotari/src/transactions/one_sided_transaction.rs
+++ b/minotari/src/transactions/one_sided_transaction.rs
@@ -41,6 +41,7 @@
 //! ```
 
 use crate::db::SqlitePool;
+use crate::transactions::idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint};
 use crate::{api::types::LockFundsResult, db::AccountRow};
 use anyhow::anyhow;
 use log::info;
@@ -86,6 +87,39 @@ pub struct Recipient {
     pub amount: MicroMinotari,
     /// Optional payment identifier or memo attached to the transaction.
     pub payment_id: Option<String>,
+}
+
+/// Binds an idempotency key to an unsigned-transaction request.
+///
+/// The recipients are the whole point of the binding. Without them, replaying a
+/// client's key with a different `recipients` list would return that client's
+/// locked UTXOs and build an unsigned transaction paying whoever the replay
+/// named. Every caller of `create_unsigned_transaction` must build its binding
+/// here so no entry point can forget a field.
+pub fn unsigned_transaction_binding(
+    idempotency_key: Option<String>,
+    account_id: i64,
+    recipients: &[Recipient],
+    fee_per_gram: MicroMinotari,
+    seconds_to_lock_utxos: u64,
+    confirmation_window: u64,
+) -> IdempotencyBinding {
+    let operation = IdempotencyOperation::CreateUnsignedTransaction;
+    let mut fingerprint = RequestFingerprint::new(operation)
+        .field("account_id", account_id.to_le_bytes())
+        .field("fee_per_gram", fee_per_gram.as_u64().to_le_bytes())
+        .field("seconds_to_lock_utxos", seconds_to_lock_utxos.to_le_bytes())
+        .field("confirmation_window", confirmation_window.to_le_bytes())
+        // Bound the list itself, so dropping or appending a recipient cannot be
+        // hidden by the remaining entries hashing the same.
+        .field("recipient_count", (recipients.len() as u64).to_le_bytes());
+    for recipient in recipients {
+        fingerprint = fingerprint
+            .field("recipient_address", recipient.address.to_base58())
+            .field("recipient_amount", recipient.amount.as_u64().to_le_bytes())
+            .optional_field("recipient_payment_id", recipient.payment_id.as_deref());
+    }
+    IdempotencyBinding::new(idempotency_key, operation, fingerprint)
 }
 
 /// Builder for creating unsigned one-sided transactions.

--- a/minotari/src/transactions/validator_node/common.rs
+++ b/minotari/src/transactions/validator_node/common.rs
@@ -4,6 +4,7 @@
 //! minimum deposit and build a single pay-to-self output with operation-specific
 //! [`OutputFeatures`]. This module extracts that common pattern.
 
+use anyhow::anyhow;
 use log::info;
 use tari_common::configuration::Network;
 use tari_common_types::transaction::TxId;
@@ -20,7 +21,10 @@ use tari_transaction_components::{
 
 use crate::{
     db::{AccountRow, SqlitePool},
-    transactions::fund_locker::FundLocker,
+    transactions::{
+        fund_locker::FundLocker,
+        idempotency::{IdempotencyBinding, IdempotencyOperation, RequestFingerprint},
+    },
 };
 
 /// Locks the VN registration deposit and prepares a pay-to-self transaction for signing.
@@ -28,6 +32,9 @@ use crate::{
 /// Used by all three VN operations (registration, exit, eviction) which share the same
 /// transaction shape: one output sent back to the sender, carrying operation-specific
 /// `output_features`.
+///
+/// `operation` both names the transaction in the audit log and scopes the
+/// idempotency key, so a registration key cannot be redeemed for an exit.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_vn_pay_to_self_tx(
     account: &AccountRow,
@@ -40,7 +47,7 @@ pub(crate) fn build_vn_pay_to_self_tx(
     idempotency_key: Option<String>,
     seconds_to_lock: u64,
     confirmation_window: u64,
-    tx_description: &str,
+    operation: IdempotencyOperation,
 ) -> Result<PrepareOneSidedTransactionForSigningResult, anyhow::Error> {
     let consensus_constants = ConsensusConstantsBuilder::new(network).build();
     let deposit_amount = consensus_constants.validator_node_registration_min_deposit_amount();
@@ -48,7 +55,26 @@ pub(crate) fn build_vn_pay_to_self_tx(
     info!(
         target: "audit",
         deposit_amount = deposit_amount.as_u64();
-        "Creating {} transaction", tx_description
+        "Creating {} transaction", operation.description()
+    );
+
+    // `output_features` carries everything that distinguishes one VN operation
+    // from another — the node public key, its signature, the claim key, the max
+    // epoch, the eviction proof — so hashing its canonical encoding binds the
+    // key to the specific node action being requested.
+    let encoded_features = serde_json::to_vec(&output_features)
+        .map_err(|e| anyhow!("Failed to encode validator node output features: {}", e))?;
+    let idempotency = IdempotencyBinding::new(
+        idempotency_key,
+        operation,
+        RequestFingerprint::new(operation)
+            .field("account_id", account.id.to_le_bytes())
+            .field("deposit_amount", deposit_amount.as_u64().to_le_bytes())
+            .field("output_features", encoded_features)
+            .field("fee_per_gram", fee_per_gram.as_u64().to_le_bytes())
+            .optional_field("payment_id", payment_id)
+            .field("seconds_to_lock", seconds_to_lock.to_le_bytes())
+            .field("confirmation_window", confirmation_window.to_le_bytes()),
     );
 
     let sender_address = account.get_address(network, password)?;
@@ -59,7 +85,7 @@ pub(crate) fn build_vn_pay_to_self_tx(
         1,
         fee_per_gram,
         None,
-        idempotency_key,
+        idempotency,
         seconds_to_lock,
         confirmation_window,
     )?;

--- a/minotari/src/transactions/validator_node/eviction.rs
+++ b/minotari/src/transactions/validator_node/eviction.rs
@@ -25,6 +25,7 @@ use tari_transaction_components::{
 
 use super::common::build_vn_pay_to_self_tx;
 use crate::db::{AccountRow, SqlitePool};
+use crate::transactions::idempotency::IdempotencyOperation;
 
 /// Parameters for validator node eviction
 ///
@@ -85,6 +86,6 @@ pub fn create_validator_node_eviction_tx(
         idempotency_key,
         seconds_to_lock,
         confirmation_window,
-        "validator node eviction proof",
+        IdempotencyOperation::ValidatorNodeEviction,
     )
 }

--- a/minotari/src/transactions/validator_node/exit.rs
+++ b/minotari/src/transactions/validator_node/exit.rs
@@ -32,6 +32,7 @@ use tari_transaction_components::{
 
 use super::common::build_vn_pay_to_self_tx;
 use crate::db::{AccountRow, SqlitePool};
+use crate::transactions::idempotency::IdempotencyOperation;
 
 /// Parameters for validator node exit
 ///
@@ -106,6 +107,6 @@ pub fn create_validator_node_exit_tx(
         idempotency_key,
         seconds_to_lock,
         confirmation_window,
-        "validator node exit",
+        IdempotencyOperation::ValidatorNodeExit,
     )
 }

--- a/minotari/src/transactions/validator_node/registration.rs
+++ b/minotari/src/transactions/validator_node/registration.rs
@@ -32,6 +32,7 @@ use tari_transaction_components::{
 
 use super::common::build_vn_pay_to_self_tx;
 use crate::db::{AccountRow, SqlitePool};
+use crate::transactions::idempotency::IdempotencyOperation;
 
 /// Parameters for validator node registration
 ///
@@ -112,6 +113,6 @@ pub fn create_validator_node_registration_tx(
         idempotency_key,
         seconds_to_lock,
         confirmation_window,
-        "validator node registration",
+        IdempotencyOperation::ValidatorNodeRegistration,
     )
 }

--- a/openapi.json
+++ b/openapi.json
@@ -252,6 +252,16 @@
               }
             }
           },
+          "409": {
+            "description": "Idempotency key reused for a different request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Burn failed",
             "content": {
@@ -455,6 +465,16 @@
           },
           "404": {
             "description": "Account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency key reused for a different request",
             "content": {
               "application/json": {
                 "schema": {
@@ -829,6 +849,16 @@
               }
             }
           },
+          "409": {
+            "description": "Idempotency key reused for a different request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {
@@ -1113,6 +1143,19 @@
           },
           {
             "type": "object",
+            "description": "The request conflicts with something the wallet has already recorded.\n\nReturned when an idempotency key is replayed with a different operation\nor a different request body, or when it belongs to a transaction that is\nalready completed or no longer active. Returns HTTP 409 Conflict.\n\n# Example\n\n```json\n{\n  \"error\": \"idempotency key 'abc' was already used for a different unsigned transaction request; a key may only be retried with the exact request that created it\"\n}\n```",
+            "required": [
+              "Conflict"
+            ],
+            "properties": {
+              "Conflict": {
+                "type": "string",
+                "description": "The request conflicts with something the wallet has already recorded.\n\nReturned when an idempotency key is replayed with a different operation\nor a different request body, or when it belongs to a transaction that is\nalready completed or no longer active. Returns HTTP 409 Conflict.\n\n# Example\n\n```json\n{\n  \"error\": \"idempotency key 'abc' was already used for a different unsigned transaction request; a key may only be retried with the exact request that created it\"\n}\n```"
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "Failed to lock funds for a transaction.\n\nThis typically occurs when there are insufficient available funds\nor when UTXO selection fails. Returns HTTP 500 Internal Server Error.\n\n# Common Causes\n\n- Insufficient balance in the account\n- All UTXOs are already locked by other pending transactions\n- UTXO selection algorithm could not find suitable inputs",
             "required": [
               "FailedToLockFunds"
@@ -1212,7 +1255,7 @@
               "string",
               "null"
             ],
-            "description": "Optional idempotency key to prevent duplicate burn requests."
+            "description": "Optional idempotency key to prevent duplicate burn requests.\n\nThe key is bound to this burn's parameters and to the burn operation\nitself, so a key issued elsewhere (for example at `lock_funds`) cannot be\nredeemed here, and reusing a burn key with different parameters is\nrejected with 409 Conflict."
           },
           "payment_id": {
             "type": [
@@ -1410,7 +1453,7 @@
               "string",
               "null"
             ],
-            "description": "Optional idempotency key to prevent duplicate transactions.\n\nIf the same key is used in multiple requests, subsequent requests will\nreturn the original transaction rather than creating a new one."
+            "description": "Optional idempotency key to prevent duplicate transactions.\n\nReusing the key returns the original transaction rather than creating a\nnew one. The key is bound to the recipients, amounts and payment ids\nbelow: a request that reuses the key with a different recipient list is\nrejected with 409 Conflict, never served from the original lock."
           },
           "recipients": {
             "type": "array",
@@ -1694,7 +1737,7 @@
               "string",
               "null"
             ],
-            "description": "Optional idempotency key to prevent duplicate requests.\n\nIf provided, subsequent requests with the same key will return the\ncached result from the original request rather than locking additional\nfunds."
+            "description": "Optional idempotency key to prevent duplicate requests.\n\nIf provided, a later request with the same key returns the cached result\nfrom the original request rather than locking additional funds.\n\nThe key is bound to this request: reusing it with any field changed, or\nat a different endpoint, is rejected with 409 Conflict instead of\nreturning the original lock. A key whose transaction has completed or\nexpired cannot be reused either."
           },
           "num_outputs": {
             "type": [


### PR DESCRIPTION
Description
---
Idempotency key isn't bound to the request body. Replay a client's key with different recipients → the cached lock short-circuits and returns the same UTXOs, producing an unsigned transaction paying the attacker. The key namespace is also shared across operations, so a /lock_funds key replayed at /burn broadcasts a burn over those UTXOs.
The intended guard exists but is only called from dead code.